### PR TITLE
Development

### DIFF
--- a/source-code/Algorithms/ocean-view/CMakeLists.txt
+++ b/source-code/Algorithms/ocean-view/CMakeLists.txt
@@ -1,22 +1,34 @@
 cmake_minimum_required(VERSION 3.20)
 project(ocean_view LANGUAGES CXX)
 
+function(target_enable_project_warnings target)
+    if(NOT TARGET "${target}")
+        message(FATAL_ERROR "target_enable_project_warnings called for unknown target: ${target}")
+    endif()
+
+    target_compile_options("${target}" PRIVATE
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wall>"
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wextra>"
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wpedantic>"
+    )
+endfunction()
+
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
 add_library(ocean_view src/ocean_view.cpp)
 target_include_directories(ocean_view PUBLIC include)
-target_compile_options(ocean_view PRIVATE -Wall -Wextra -Wpedantic)
+target_enable_project_warnings(ocean_view)
 
 add_executable(ocean_view_test tests/main_test.cpp)
 target_link_libraries(ocean_view_test PRIVATE ocean_view)
-target_compile_options(ocean_view_test PRIVATE -Wall -Wextra -Wpedantic)
+target_enable_project_warnings(ocean_view_test)
 
 add_executable(ocean_view_timings benchmarks/main_timing.cpp)
 target_link_libraries(ocean_view_timings PRIVATE ocean_view)
-target_compile_options(ocean_view_timings PRIVATE -Wall -Wextra -Wpedantic)
+target_enable_project_warnings(ocean_view_timings)
 
 add_executable(ocean_view_timings2 benchmarks/main_timing2.cpp)
 target_link_libraries(ocean_view_timings2 PRIVATE ocean_view)
-target_compile_options(ocean_view_timings2 PRIVATE -Wall -Wextra -Wpedantic)
+target_enable_project_warnings(ocean_view_timings2)

--- a/source-code/Algorithms/std-algorithms/CMakeLists.txt
+++ b/source-code/Algorithms/std-algorithms/CMakeLists.txt
@@ -1,6 +1,18 @@
 cmake_minimum_required(VERSION 3.20)
 project(std_algorithms LANGUAGES CXX)
 
+function(target_enable_project_warnings target)
+    if(NOT TARGET "${target}")
+        message(FATAL_ERROR "target_enable_project_warnings called for unknown target: ${target}")
+    endif()
+
+    target_compile_options("${target}" PRIVATE
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wall>"
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wextra>"
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wpedantic>"
+    )
+endfunction()
+
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
@@ -22,5 +34,5 @@ set(APPLICATIONS
 
 foreach(APP ${APPLICATIONS})
     add_executable(${APP}.exe ${APP}.cpp)
-    target_compile_options(${APP}.exe PRIVATE -Wall -Wextra -Wpedantic)
+target_enable_project_warnings(${APP}.exe)
 endforeach()

--- a/source-code/Armadillo/CMakeLists.txt
+++ b/source-code/Armadillo/CMakeLists.txt
@@ -2,6 +2,18 @@ cmake_minimum_required(VERSION 3.22)
 
 project(armadillo LANGUAGES CXX)
 
+function(target_enable_project_warnings target)
+    if(NOT TARGET "${target}")
+        message(FATAL_ERROR "target_enable_project_warnings called for unknown target: ${target}")
+    endif()
+
+    target_compile_options("${target}" PRIVATE
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wall>"
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wextra>"
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wpedantic>"
+    )
+endfunction()
+
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
@@ -21,5 +33,5 @@ set(APPLICATIONS
 foreach(APP ${APPLICATIONS})
     add_executable(${APP}.exe ${APP}.cpp)
     target_link_libraries(${APP}.exe PRIVATE ${ARMADILLO_LIBRARIES})
-    target_compile_options(${APP}.exe PRIVATE -Wall -Wextra -pedantic)
+target_enable_project_warnings(${APP}.exe)
 endforeach()

--- a/source-code/Armadillo/CMakeLists.txt
+++ b/source-code/Armadillo/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.22)
+cmake_minimum_required(VERSION 3.20)
 
 project(armadillo LANGUAGES CXX)
 

--- a/source-code/Assembler/CalcSum/CMakeLists.txt
+++ b/source-code/Assembler/CalcSum/CMakeLists.txt
@@ -1,6 +1,18 @@
 cmake_minimum_required(VERSION 3.20)
 project(assembler_calc_sum LANGUAGES CXX ASM_NASM)
 
+function(target_enable_project_warnings target)
+    if(NOT TARGET "${target}")
+        message(FATAL_ERROR "target_enable_project_warnings called for unknown target: ${target}")
+    endif()
+
+    target_compile_options("${target}" PRIVATE
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wall>"
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wextra>"
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wpedantic>"
+    )
+endfunction()
+
 set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
@@ -16,5 +28,5 @@ set_source_files_properties(
 )
 
 foreach(app calc_sum.exe timing.exe timing_compiler.exe)
-    target_compile_options(${app} PRIVATE -Wall -Wextra -Wpedantic)
+target_enable_project_warnings(${app})
 endforeach()

--- a/source-code/Assembler/Quadratic/CMakeLists.txt
+++ b/source-code/Assembler/Quadratic/CMakeLists.txt
@@ -1,6 +1,18 @@
 cmake_minimum_required(VERSION 3.20)
 project(assembler_quadratic LANGUAGES CXX ASM_NASM)
 
+function(target_enable_project_warnings target)
+    if(NOT TARGET "${target}")
+        message(FATAL_ERROR "target_enable_project_warnings called for unknown target: ${target}")
+    endif()
+
+    target_compile_options("${target}" PRIVATE
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wall>"
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wextra>"
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wpedantic>"
+    )
+endfunction()
+
 set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
@@ -12,5 +24,5 @@ add_executable(timing.exe timing.cpp quad.nsm)
 add_executable(quad_calc_inline.exe quad_calc_inline.cpp)
 
 foreach(app quad_calc.exe timing.exe quad_calc_inline.exe)
-    target_compile_options(${app} PRIVATE -Wall -Wextra -Wpedantic)
+target_enable_project_warnings(${app})
 endforeach()

--- a/source-code/Basics/CMakeLists.txt
+++ b/source-code/Basics/CMakeLists.txt
@@ -2,6 +2,19 @@ cmake_minimum_required(VERSION 3.20)
 
 # Set project name and C++ standard
 project(MyExecutables CXX)
+
+function(target_enable_project_warnings target)
+    if(NOT TARGET "${target}")
+        message(FATAL_ERROR "target_enable_project_warnings called for unknown target: ${target}")
+    endif()
+
+    target_compile_options("${target}" PRIVATE
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wall>"
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wextra>"
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wpedantic>"
+    )
+endfunction()
+
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
@@ -26,5 +39,5 @@ set(APPL
 # Add an executable for each .cpp file
 foreach(app ${APPL})
     add_executable(${app}.exe ${app}.cpp)
-    target_compile_options(${app}.exe PRIVATE -Wall -Wextra)
+target_enable_project_warnings(${app}.exe)
 endforeach()

--- a/source-code/Boost/Bimap/CMakeLists.txt
+++ b/source-code/Boost/Bimap/CMakeLists.txt
@@ -1,17 +1,28 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.20)
 project(bimaps LANGUAGES CXX)
+
+function(target_enable_project_warnings target)
+    if(NOT TARGET "${target}")
+        message(FATAL_ERROR "target_enable_project_warnings called for unknown target: ${target}")
+    endif()
+
+    target_compile_options("${target}" PRIVATE
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wall>"
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wextra>"
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wpedantic>"
+    )
+endfunction()
 
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED YES)
 set(CMAKE_CXX_EXTENSION NO)
 
-add_compile_options(-Wall -Wextra -Wpedantic)
+if(POLICY CMP0167)
+    cmake_policy(SET CMP0167 NEW)
+endif()
 
-find_package(Boost)
-if (NOT Boost_FOUND)
-    message(FATAL_ERROR "Boost is required but can't be found")
-endif (NOT Boost_FOUND)
+find_package(Boost CONFIG REQUIRED)
 
 add_executable(bimap.exe bimap.cpp)
-target_include_directories(bimap.exe PRIVATE ${Boost_INCLUDE_DIR})
-target_link_libraries(bimap.exe LINK_PRIVATE ${Boost_LIBRARIES})
+target_enable_project_warnings(bimap.exe)
+target_link_libraries(bimap.exe PRIVATE Boost::headers)

--- a/source-code/Boost/Coroutines/CMakeLists.txt
+++ b/source-code/Boost/Coroutines/CMakeLists.txt
@@ -1,12 +1,28 @@
 cmake_minimum_required(VERSION 3.20)
 project(boost_coroutines_examples LANGUAGES CXX)
 
+function(target_enable_project_warnings target)
+    if(NOT TARGET "${target}")
+        message(FATAL_ERROR "target_enable_project_warnings called for unknown target: ${target}")
+    endif()
+
+    target_compile_options("${target}" PRIVATE
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wall>"
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wextra>"
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wpedantic>"
+    )
+endfunction()
+
 set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
-find_package(Boost REQUIRED COMPONENTS coroutine context)
+if(POLICY CMP0167)
+    cmake_policy(SET CMP0167 NEW)
+endif()
+
+find_package(Boost CONFIG REQUIRED COMPONENTS coroutine context)
 
 add_executable(range.exe range.cpp)
-target_compile_options(range.exe PRIVATE -Wall -Wextra)
+target_enable_project_warnings(range.exe)
 target_link_libraries(range.exe PRIVATE Boost::coroutine Boost::context)

--- a/source-code/Boost/Logging/CMakeLists.txt
+++ b/source-code/Boost/Logging/CMakeLists.txt
@@ -1,21 +1,34 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.20)
 project(Logging LANGUAGES CXX)
+
+function(target_enable_project_warnings target)
+    if(NOT TARGET "${target}")
+        message(FATAL_ERROR "target_enable_project_warnings called for unknown target: ${target}")
+    endif()
+
+    target_compile_options("${target}" PRIVATE
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wall>"
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wextra>"
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wpedantic>"
+    )
+endfunction()
 
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED YES)
 set(CMAKE_CXX_EXTENSION NO)
 
-add_compile_options(-Wall -Wextra -Wpedantic)
+if(POLICY CMP0167)
+    cmake_policy(SET CMP0167 NEW)
+endif()
 
-find_package(Boost COMPONENTS log log_setup filesystem)
-if (NOT Boost_FOUND)
-    message(FATAL_ERROR "Boost is required but can't be found")
-endif (NOT Boost_FOUND)
+find_package(Boost CONFIG REQUIRED COMPONENTS log log_setup filesystem)
 
 add_executable(file_logging.exe file_logging.cpp)
-target_include_directories(file_logging.exe PRIVATE ${Boost_INCLUDE_DIR})
-target_link_libraries(file_logging.exe LINK_PRIVATE ${Boost_LIBRARIES})
+target_enable_project_warnings(file_logging.exe)
+target_link_libraries(file_logging.exe
+    PRIVATE Boost::log Boost::log_setup Boost::filesystem)
 
 add_executable(auto_flush.exe auto_flush.cpp)
-target_include_directories(auto_flush.exe PRIVATE ${Boost_INCLUDE_DIR})
-target_link_libraries(auto_flush.exe LINK_PRIVATE ${Boost_LIBRARIES})
+target_enable_project_warnings(auto_flush.exe)
+target_link_libraries(auto_flush.exe
+    PRIVATE Boost::log Boost::log_setup Boost::filesystem)

--- a/source-code/Boost/Math/Brent/CMakeLists.txt
+++ b/source-code/Boost/Math/Brent/CMakeLists.txt
@@ -1,17 +1,28 @@
 cmake_minimum_required(VERSION 3.20)
 project(brent LANGUAGES CXX)
 
+function(target_enable_project_warnings target)
+    if(NOT TARGET "${target}")
+        message(FATAL_ERROR "target_enable_project_warnings called for unknown target: ${target}")
+    endif()
+
+    target_compile_options("${target}" PRIVATE
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wall>"
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wextra>"
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wpedantic>"
+    )
+endfunction()
+
 set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_STANDARD_REQUIRED YES)
 set(CMAKE_CXX_EXTENSION NO)
 
-add_compile_options(-Wall -Wextra -Wpedantic)
+if(POLICY CMP0167)
+    cmake_policy(SET CMP0167 NEW)
+endif()
 
-find_package(Boost)
-if (NOT Boost_FOUND)
-    message(FATAL_ERROR "Boost is required but can't be found")
-endif (NOT Boost_FOUND)
+find_package(Boost CONFIG REQUIRED)
 
 add_executable(brent.exe brent_optimization.cpp)
-target_include_directories(brent.exe PRIVATE ${Boost_INCLUDE_DIR})
-target_link_libraries(brent.exe LINK_PRIVATE ${Boost_LIBRARIES})
+target_enable_project_warnings(brent.exe)
+target_link_libraries(brent.exe PRIVATE Boost::headers)

--- a/source-code/Boost/Math/Odeint/CMakeLists.txt
+++ b/source-code/Boost/Math/Odeint/CMakeLists.txt
@@ -1,17 +1,28 @@
 cmake_minimum_required(VERSION 3.20)
 project(lorenz LANGUAGES CXX)
 
+function(target_enable_project_warnings target)
+    if(NOT TARGET "${target}")
+        message(FATAL_ERROR "target_enable_project_warnings called for unknown target: ${target}")
+    endif()
+
+    target_compile_options("${target}" PRIVATE
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wall>"
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wextra>"
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wpedantic>"
+    )
+endfunction()
+
 set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_STANDARD_REQUIRED YES)
 set(CMAKE_CXX_EXTENSION NO)
 
-add_compile_options(-Wall -Wextra -Wpedantic)
+if(POLICY CMP0167)
+    cmake_policy(SET CMP0167 NEW)
+endif()
 
-find_package(Boost)
-if (NOT Boost_FOUND)
-    message(FATAL_ERROR "Boost is required but can't be found")
-endif (NOT Boost_FOUND)
+find_package(Boost CONFIG REQUIRED)
 
 add_executable(lorenz.exe lorenz.cpp)
-target_include_directories(lorenz.exe PRIVATE ${Boost_INCLUDE_DIR})
-target_link_libraries(lorenz.exe LINK_PRIVATE ${Boost_LIBRARIES})
+target_enable_project_warnings(lorenz.exe)
+target_link_libraries(lorenz.exe PRIVATE Boost::headers)

--- a/source-code/Boost/Math/Quadratures/CMakeLists.txt
+++ b/source-code/Boost/Math/Quadratures/CMakeLists.txt
@@ -1,17 +1,28 @@
 cmake_minimum_required(VERSION 3.20)
 project(gauss LANGUAGES CXX)
 
+function(target_enable_project_warnings target)
+    if(NOT TARGET "${target}")
+        message(FATAL_ERROR "target_enable_project_warnings called for unknown target: ${target}")
+    endif()
+
+    target_compile_options("${target}" PRIVATE
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wall>"
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wextra>"
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wpedantic>"
+    )
+endfunction()
+
 set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_STANDARD_REQUIRED YES)
 set(CMAKE_CXX_EXTENSION NO)
 
-add_compile_options(-Wall -Wextra -Wpedantic)
+if(POLICY CMP0167)
+    cmake_policy(SET CMP0167 NEW)
+endif()
 
-find_package(Boost)
-if (NOT Boost_FOUND)
-    message(FATAL_ERROR "Boost is required but can't be found")
-endif (NOT Boost_FOUND)
+find_package(Boost CONFIG REQUIRED)
 
 add_executable(quad.exe quad.cpp)
-target_include_directories(quad.exe PRIVATE ${Boost_INCLUDE_DIR})
-target_link_libraries(quad.exe LINK_PRIVATE ${Boost_LIBRARIES})
+target_enable_project_warnings(quad.exe)
+target_link_libraries(quad.exe PRIVATE Boost::headers)

--- a/source-code/Boost/Process/CMakeLists.txt
+++ b/source-code/Boost/Process/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.22)
+cmake_minimum_required(VERSION 3.20)
 
 project(boost_process LANGUAGES CXX)
 

--- a/source-code/Boost/Process/CMakeLists.txt
+++ b/source-code/Boost/Process/CMakeLists.txt
@@ -2,16 +2,35 @@ cmake_minimum_required(VERSION 3.22)
 
 project(boost_process LANGUAGES CXX)
 
+
+function(target_enable_project_warnings target)
+    if(NOT TARGET "${target}")
+        message(FATAL_ERROR "target_enable_project_warnings called for unknown target: ${target}")
+    endif()
+
+    target_compile_options("${target}" PRIVATE
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wall>"
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wextra>"
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wpedantic>"
+    )
+endfunction()
+
 set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
-set(Boost_USE_MULTITHREADED ON)
-find_package(Boost REQUIRED COMPONENTS system filesystem)
+if(POLICY CMP0167)
+    cmake_policy(SET CMP0167 NEW)
+endif()
+
+find_package(Boost CONFIG REQUIRED COMPONENTS system filesystem)
 
 add_executable(ls_boost.exe ls.cpp)
-target_link_libraries(ls_boost.exe Boost::system Boost::filesystem)
+target_enable_project_warnings(ls_boost.exe)
+target_link_libraries(ls_boost.exe PRIVATE Boost::system Boost::filesystem)
 add_executable(bc_boost.exe bc.cpp)
-target_link_libraries(bc_boost.exe Boost::system Boost::filesystem)
+target_enable_project_warnings(bc_boost.exe)
+target_link_libraries(bc_boost.exe PRIVATE Boost::system Boost::filesystem)
 add_executable(env_boost.exe env.cpp)
-target_link_libraries(env_boost.exe Boost::system Boost::filesystem)
+target_enable_project_warnings(env_boost.exe)
+target_link_libraries(env_boost.exe PRIVATE Boost::system Boost::filesystem)

--- a/source-code/Boost/ProgramOptions/CMakeLists.txt
+++ b/source-code/Boost/ProgramOptions/CMakeLists.txt
@@ -1,21 +1,32 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.20)
 project(ProgramOptions LANGUAGES CXX)
+
+function(target_enable_project_warnings target)
+    if(NOT TARGET "${target}")
+        message(FATAL_ERROR "target_enable_project_warnings called for unknown target: ${target}")
+    endif()
+
+    target_compile_options("${target}" PRIVATE
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wall>"
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wextra>"
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wpedantic>"
+    )
+endfunction()
 
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED YES)
 set(CMAKE_CXX_EXTENSION NO)
 
-add_compile_options(-Wall -Wextra -Wpedantic)
+if(POLICY CMP0167)
+    cmake_policy(SET CMP0167 NEW)
+endif()
 
-find_package(Boost COMPONENTS program_options)
-if (NOT Boost_FOUND)
-    message(FATAL_ERROR "Boost is required but can't be found")
-endif (NOT Boost_FOUND)
+find_package(Boost CONFIG REQUIRED COMPONENTS program_options)
 
 add_executable(random.exe random.cpp)
-target_include_directories(random.exe PRIVATE ${Boost_INCLUDE_DIR})
-target_link_libraries(random.exe LINK_PRIVATE ${Boost_LIBRARIES})
+target_enable_project_warnings(random.exe)
+target_link_libraries(random.exe PRIVATE Boost::program_options)
 
 add_executable(random_default.exe random_default.cpp)
-target_include_directories(random_default.exe PRIVATE ${Boost_INCLUDE_DIR})
-target_link_libraries(random_default.exe LINK_PRIVATE ${Boost_LIBRARIES})
+target_enable_project_warnings(random_default.exe)
+target_link_libraries(random_default.exe PRIVATE Boost::program_options)

--- a/source-code/Boost/Tokenizer/CMakeLists.txt
+++ b/source-code/Boost/Tokenizer/CMakeLists.txt
@@ -2,6 +2,18 @@ cmake_minimum_required(VERSION 3.20)
 
 project(tabular LANGUAGES CXX)
 
+function(target_enable_project_warnings target)
+    if(NOT TARGET "${target}")
+        message(FATAL_ERROR "target_enable_project_warnings called for unknown target: ${target}")
+    endif()
+
+    target_compile_options("${target}" PRIVATE
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wall>"
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wextra>"
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wpedantic>"
+    )
+endfunction()
+
 set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
@@ -11,13 +23,10 @@ if(POLICY CMP0167)
   cmake_policy(SET CMP0167 NEW)
 endif()
 
-find_package(Boost REQUIRED COMPONENTS program_options)
+find_package(Boost CONFIG REQUIRED COMPONENTS program_options)
 
 add_executable(tabular_sum.exe
     tabular_sum.cpp)
-target_include_directories(tabular_sum.exe
-    PRIVATE Boost::Boost)
 target_link_libraries(tabular_sum.exe
     PRIVATE Boost::program_options)
-target_compile_options(tabular_sum.exe
-    PRIVATE -Wall -Wextra -pedantic)
+target_enable_project_warnings(tabular_sum.exe)

--- a/source-code/Boost/Units/CMakeLists.txt
+++ b/source-code/Boost/Units/CMakeLists.txt
@@ -2,22 +2,37 @@ cmake_minimum_required(VERSION 3.20)
 
 project(boost_units_examples LANGUAGES CXX)
 
+
+function(target_enable_project_warnings target)
+    if(NOT TARGET "${target}")
+        message(FATAL_ERROR "target_enable_project_warnings called for unknown target: ${target}")
+    endif()
+
+    target_compile_options("${target}" PRIVATE
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wall>"
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wextra>"
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wpedantic>"
+    )
+endfunction()
+
+function(project_warning_options_for_compiler output_variable)
+    if(CMAKE_CXX_COMPILER_ID MATCHES "^(GNU|Clang|AppleClang|IntelLLVM)$")
+        set(${output_variable} -Wall -Wextra -Wpedantic PARENT_SCOPE)
+    else()
+        set(${output_variable} "" PARENT_SCOPE)
+    endif()
+endfunction()
+
 if(POLICY CMP0167)
     cmake_policy(SET CMP0167 NEW)
 endif()
 
 find_package(Boost CONFIG REQUIRED)
 
-set(common_cxx_options
-    -Wall
-    -Wextra
-    -Wpedantic
-)
-
 add_executable(units_okay units_okay.cpp)
 set_target_properties(units_okay PROPERTIES OUTPUT_NAME "units_okay.exe")
 target_compile_features(units_okay PRIVATE cxx_std_17)
-target_compile_options(units_okay PRIVATE ${common_cxx_options})
+target_enable_project_warnings(units_okay)
 target_link_libraries(units_okay PRIVATE Boost::headers)
 
 set(not_okay_object "${CMAKE_CURRENT_BINARY_DIR}/units_not_okay.o")
@@ -25,36 +40,34 @@ set(not_okay_script
     "${CMAKE_CURRENT_BINARY_DIR}/compile_units_not_okay.cmake"
 )
 set(not_okay_include_args "")
+set(not_okay_warning_args "")
+project_warning_options_for_compiler(not_okay_warning_options)
 
-if(Boost_INCLUDE_DIRS)
-    foreach(include_dir IN LISTS Boost_INCLUDE_DIRS)
+foreach(option IN LISTS not_okay_warning_options)
+    string(APPEND not_okay_warning_args
+        "          \"${option}\"\n"
+    )
+endforeach()
+
+get_target_property(
+    boost_header_include_dirs
+    Boost::headers
+    INTERFACE_INCLUDE_DIRECTORIES
+)
+foreach(include_dir IN LISTS boost_header_include_dirs)
+    if(NOT include_dir MATCHES "^\\$<")
         string(APPEND not_okay_include_args
             "          -I\n"
             "          \"${include_dir}\"\n"
         )
-    endforeach()
-else()
-    get_target_property(
-        boost_header_include_dirs
-        Boost::headers
-        INTERFACE_INCLUDE_DIRECTORIES
-    )
-    foreach(include_dir IN LISTS boost_header_include_dirs)
-        if(NOT include_dir MATCHES "^\\$<")
-            string(APPEND not_okay_include_args
-                "          -I\n"
-                "          \"${include_dir}\"\n"
-            )
-        endif()
-    endforeach()
-endif()
+    endif()
+endforeach()
 
 file(WRITE "${not_okay_script}"
 "execute_process(\n"
 "  COMMAND \"${CMAKE_CXX_COMPILER}\"\n"
 "          -std=c++14\n"
-"          -Wall\n"
-"          -Wextra\n"
+"${not_okay_warning_args}"
 "${not_okay_include_args}"
 "          -c\n"
 "          \"${CMAKE_CURRENT_SOURCE_DIR}/units_not_okay.cpp\"\n"

--- a/source-code/Boost/Vector/CMakeLists.txt
+++ b/source-code/Boost/Vector/CMakeLists.txt
@@ -1,10 +1,22 @@
 cmake_minimum_required(VERSION 3.20)
 project(boost_vector_example LANGUAGES CXX)
 
+function(target_enable_project_warnings target)
+    if(NOT TARGET "${target}")
+        message(FATAL_ERROR "target_enable_project_warnings called for unknown target: ${target}")
+    endif()
+
+    target_compile_options("${target}" PRIVATE
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wall>"
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wextra>"
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wpedantic>"
+    )
+endfunction()
+
 set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
 add_executable(boost_vector.exe boost_vector.cpp)
-target_compile_options(boost_vector.exe PRIVATE -Wall -Wextra)
+target_enable_project_warnings(boost_vector.exe)
 target_link_libraries(boost_vector.exe PRIVATE m)

--- a/source-code/CLI11/CMakeLists.txt
+++ b/source-code/CLI11/CMakeLists.txt
@@ -1,6 +1,19 @@
 cmake_minimum_required(VERSION 3.20)
 project(random_numbers LANGUAGES CXX)
 
+
+function(target_enable_project_warnings target)
+    if(NOT TARGET "${target}")
+        message(FATAL_ERROR "target_enable_project_warnings called for unknown target: ${target}")
+    endif()
+
+    target_compile_options("${target}" PRIVATE
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wall>"
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wextra>"
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wpedantic>"
+    )
+endfunction()
+
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
@@ -18,4 +31,5 @@ FetchContent_MakeAvailable(cli11_proj)
 add_executable(random_default.exe
     random_default.cpp
 )
+target_enable_project_warnings(random_default.exe)
 target_link_libraries(random_default.exe PRIVATE CLI11::CLI11)

--- a/source-code/CPM/CMakeLists.txt
+++ b/source-code/CPM/CMakeLists.txt
@@ -1,11 +1,21 @@
 cmake_minimum_required(VERSION 3.14 FATAL_ERROR)
 project(MyProject LANGUAGES CXX)
 
+function(target_enable_project_warnings target)
+    if(NOT TARGET "${target}")
+        message(FATAL_ERROR "target_enable_project_warnings called for unknown target: ${target}")
+    endif()
+
+    target_compile_options("${target}" PRIVATE
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wall>"
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wextra>"
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wpedantic>"
+    )
+endfunction()
+
 set(CMAKE_CXX_STANDARD 20)
 set(CMaKE_CXX_STANDARD_REQUIRED YES)
 set(CMAKE_CXX_EXTENSIONS NO)
-
-add_compile_options(-Wall -Wextra -Wpedantic)
 
 # if necessary download and install CPM
 set(CPM_DOWNLOAD_VERSION 0.38.1)
@@ -33,5 +43,6 @@ CPMAddPackage("gh:fmtlib/fmt#9.1.0")
 
 add_executable(fmt_test.exe
     main.cpp)
+target_enable_project_warnings(fmt_test.exe)
 target_link_libraries(fmt_test.exe
     fmt::fmt)

--- a/source-code/CPM/CMakeLists.txt
+++ b/source-code/CPM/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.14 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.20)
 project(MyProject LANGUAGES CXX)
 
 function(target_enable_project_warnings target)

--- a/source-code/Classes/CMakeLists.txt
+++ b/source-code/Classes/CMakeLists.txt
@@ -2,6 +2,18 @@ cmake_minimum_required(VERSION 3.20)
 
 project(late_binding LANGUAGES CXX)
 
+function(target_enable_project_warnings target)
+    if(NOT TARGET "${target}")
+        message(FATAL_ERROR "target_enable_project_warnings called for unknown target: ${target}")
+    endif()
+
+    target_compile_options("${target}" PRIVATE
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wall>"
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wextra>"
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wpedantic>"
+    )
+endfunction()
+
 set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
@@ -13,6 +25,5 @@ set(APPLICATIONS
 
 foreach(appl IN LISTS APPLICATIONS)
     add_executable(${appl}.exe ${appl}.cpp)
-    # Compiler flags matching Makefile: -Wall, -Wextra, -Wpedantic
-    target_compile_options(${appl}.exe PRIVATE -Wall -Wextra -Wpedantic)
+    target_enable_project_warnings(${appl}.exe)
 endforeach()

--- a/source-code/Classes/LateBinding/CMakeLists.txt
+++ b/source-code/Classes/LateBinding/CMakeLists.txt
@@ -2,6 +2,18 @@ cmake_minimum_required(VERSION 3.20)
 
 project(quadrature LANGUAGES CXX)
 
+function(target_enable_project_warnings target)
+    if(NOT TARGET "${target}")
+        message(FATAL_ERROR "target_enable_project_warnings called for unknown target: ${target}")
+    endif()
+
+    target_compile_options("${target}" PRIVATE
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wall>"
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wextra>"
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wpedantic>"
+    )
+endfunction()
+
 set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS ON)    
@@ -10,5 +22,4 @@ add_executable(stats.exe
     stats.cpp
     median_stats.cpp
     stats_main.cpp)
-target_compile_options(stats.exe
-    PRIVATE -Wall -Wextra -Wpedantic)
+target_enable_project_warnings(stats.exe)

--- a/source-code/Classes/Mixin/CMakeLists.txt
+++ b/source-code/Classes/Mixin/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.20)
 project(mixin LANGUAGES CXX)
 
 function(target_enable_project_warnings target)

--- a/source-code/Classes/Mixin/CMakeLists.txt
+++ b/source-code/Classes/Mixin/CMakeLists.txt
@@ -1,11 +1,22 @@
 cmake_minimum_required(VERSION 3.0)
 project(mixin LANGUAGES CXX)
 
+function(target_enable_project_warnings target)
+    if(NOT TARGET "${target}")
+        message(FATAL_ERROR "target_enable_project_warnings called for unknown target: ${target}")
+    endif()
+
+    target_compile_options("${target}" PRIVATE
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wall>"
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wextra>"
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wpedantic>"
+    )
+endfunction()
+
 set(CMAKE_CXX_STANDARD 20)
 set(CMaKE_CXX_STANDARD_REQUIRED YES)
 set(CMAKE_CXX_EXTENSIONS NO)
 
-add_compile_options(-Wall -Wextra -Wpedantic)
-
 add_executable(colors.exe
     main.cpp)
+target_enable_project_warnings(colors.exe)

--- a/source-code/Classes/Particles/CMakeLists.txt
+++ b/source-code/Classes/Particles/CMakeLists.txt
@@ -2,6 +2,18 @@ cmake_minimum_required(VERSION 3.20)
 
 project(particles LANGUAGES CXX)
 
+function(target_enable_project_warnings target)
+    if(NOT TARGET "${target}")
+        message(FATAL_ERROR "target_enable_project_warnings called for unknown target: ${target}")
+    endif()
+
+    target_compile_options("${target}" PRIVATE
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wall>"
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wextra>"
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wpedantic>"
+    )
+endfunction()
+
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
@@ -10,4 +22,4 @@ add_executable(particles.exe
     main.cpp
     particle.cpp
     static_particle.cpp)
-target_compile_options(particles.exe PRIVATE -Wall -Wextra -Wpedantic)
+target_enable_project_warnings(particles.exe)

--- a/source-code/Classes/QuadratureImplementations/Quadrature/CMakeLists.txt
+++ b/source-code/Classes/QuadratureImplementations/Quadrature/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.16)
+cmake_minimum_required(VERSION 3.20)
 
 project(quadrature LANGUAGES CXX)
 

--- a/source-code/Classes/QuadratureImplementations/Quadrature/CMakeLists.txt
+++ b/source-code/Classes/QuadratureImplementations/Quadrature/CMakeLists.txt
@@ -2,6 +2,18 @@ cmake_minimum_required(VERSION 3.16)
 
 project(quadrature LANGUAGES CXX)
 
+function(target_enable_project_warnings target)
+    if(NOT TARGET "${target}")
+        message(FATAL_ERROR "target_enable_project_warnings called for unknown target: ${target}")
+    endif()
+
+    target_compile_options("${target}" PRIVATE
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wall>"
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wextra>"
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wpedantic>"
+    )
+endfunction()
+
 set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
@@ -16,10 +28,7 @@ add_executable(quad
 set_target_properties(quad PROPERTIES OUTPUT_NAME "quad.exe")
 
 # Match Makefile warning flags.
-target_compile_options(quad PRIVATE
-    -Wall
-    -Wextra
-)
+target_enable_project_warnings(quad)
 
 # Link against libm as in LDLIBS = -lm.
 target_link_libraries(quad PRIVATE m)

--- a/source-code/Classes/QuadratureImplementations/Quadrature_CRTP/CMakeLists.txt
+++ b/source-code/Classes/QuadratureImplementations/Quadrature_CRTP/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.20)
 project(quadrature LANGUAGES CXX)
 
 function(target_enable_project_warnings target)

--- a/source-code/Classes/QuadratureImplementations/Quadrature_CRTP/CMakeLists.txt
+++ b/source-code/Classes/QuadratureImplementations/Quadrature_CRTP/CMakeLists.txt
@@ -1,11 +1,22 @@
 cmake_minimum_required(VERSION 3.0)
 project(quadrature LANGUAGES CXX)
 
+function(target_enable_project_warnings target)
+    if(NOT TARGET "${target}")
+        message(FATAL_ERROR "target_enable_project_warnings called for unknown target: ${target}")
+    endif()
+
+    target_compile_options("${target}" PRIVATE
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wall>"
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wextra>"
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wpedantic>"
+    )
+endfunction()
+
 set(CMAKE_CXX_STANDARD 20)
 set(CMaKE_CXX_STANDARD_REQUIRED YES)
 set(CMAKE_CXX_EXTENSIONS NO)
 
-add_compile_options(-Wall -Wextra -Wpedantic)
-
 add_executable(quad.exe
     main_quad.cpp simpson_quad.cpp gaussian_quad.cpp)
+target_enable_project_warnings(quad.exe)

--- a/source-code/Classes/QuadratureImplementations/Quadrature_benchmark/CMakeLists.txt
+++ b/source-code/Classes/QuadratureImplementations/Quadrature_benchmark/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.16)
+cmake_minimum_required(VERSION 3.20)
 
 project(quadrature_dispatch_benchmark LANGUAGES CXX)
 

--- a/source-code/Classes/QuadratureImplementations/Quadrature_benchmark/CMakeLists.txt
+++ b/source-code/Classes/QuadratureImplementations/Quadrature_benchmark/CMakeLists.txt
@@ -2,6 +2,18 @@ cmake_minimum_required(VERSION 3.16)
 
 project(quadrature_dispatch_benchmark LANGUAGES CXX)
 
+function(target_enable_project_warnings target)
+    if(NOT TARGET "${target}")
+        message(FATAL_ERROR "target_enable_project_warnings called for unknown target: ${target}")
+    endif()
+
+    target_compile_options("${target}" PRIVATE
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wall>"
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wextra>"
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wpedantic>"
+    )
+endfunction()
+
 if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
     set(CMAKE_BUILD_TYPE Release CACHE STRING "Build type" FORCE)
 endif()
@@ -46,6 +58,7 @@ foreach(target
         bench_crtp.exe
         bench_duck_typing.exe
         bench_duck_typing_template.exe)
-    target_compile_options(${target} PRIVATE -O3 -DNDEBUG -Wall -Wextra -Wpedantic)
+    target_compile_options(${target} PRIVATE -O3 -DNDEBUG)
+target_enable_project_warnings(${target})
     target_link_libraries(${target} PRIVATE m)
 endforeach()

--- a/source-code/Classes/QuadratureImplementations/Quadrature_concept/CMakeLists.txt
+++ b/source-code/Classes/QuadratureImplementations/Quadrature_concept/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.16)
+cmake_minimum_required(VERSION 3.20)
 
 project(IntegrateConcept LANGUAGES CXX)
 

--- a/source-code/Classes/QuadratureImplementations/Quadrature_concept/CMakeLists.txt
+++ b/source-code/Classes/QuadratureImplementations/Quadrature_concept/CMakeLists.txt
@@ -2,6 +2,18 @@ cmake_minimum_required(VERSION 3.16)
 
 project(IntegrateConcept LANGUAGES CXX)
 
+function(target_enable_project_warnings target)
+    if(NOT TARGET "${target}")
+        message(FATAL_ERROR "target_enable_project_warnings called for unknown target: ${target}")
+    endif()
+
+    target_compile_options("${target}" PRIVATE
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wall>"
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wextra>"
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wpedantic>"
+    )
+endfunction()
+
 add_executable(
     quad
     gaussian_quad.cpp
@@ -19,7 +31,8 @@ set_target_properties(
 target_compile_features(quad PRIVATE cxx_std_20)
 
 if(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
-    target_compile_options(quad PRIVATE -Wall -Wextra -O2 -g)
+    target_compile_options(quad PRIVATE -O2 -g)
 endif()
+target_enable_project_warnings(quad)
 
 target_link_libraries(quad PRIVATE m)

--- a/source-code/Classes/QuadratureImplementations/Quadrature_concept_template/CMakeLists.txt
+++ b/source-code/Classes/QuadratureImplementations/Quadrature_concept_template/CMakeLists.txt
@@ -2,6 +2,18 @@ cmake_minimum_required(VERSION 3.16)
 
 project(IntegrateConceptTemplate LANGUAGES CXX)
 
+function(target_enable_project_warnings target)
+    if(NOT TARGET "${target}")
+        message(FATAL_ERROR "target_enable_project_warnings called for unknown target: ${target}")
+    endif()
+
+    target_compile_options("${target}" PRIVATE
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wall>"
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wextra>"
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wpedantic>"
+    )
+endfunction()
+
 add_executable(
     quad
     gaussian_quad.cpp
@@ -18,7 +30,8 @@ set_target_properties(
 target_compile_features(quad PRIVATE cxx_std_20)
 
 if(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
-    target_compile_options(quad PRIVATE -Wall -Wextra -O2 -g)
+    target_compile_options(quad PRIVATE -O2 -g)
 endif()
+target_enable_project_warnings(quad)
 
 target_link_libraries(quad PRIVATE m)

--- a/source-code/Classes/QuadratureImplementations/Quadrature_concept_template/CMakeLists.txt
+++ b/source-code/Classes/QuadratureImplementations/Quadrature_concept_template/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.16)
+cmake_minimum_required(VERSION 3.20)
 
 project(IntegrateConceptTemplate LANGUAGES CXX)
 

--- a/source-code/Classes/QuadratureImplementations/Quadrature_deduce_this/CMakeLists.txt
+++ b/source-code/Classes/QuadratureImplementations/Quadrature_deduce_this/CMakeLists.txt
@@ -1,11 +1,22 @@
 cmake_minimum_required(VERSION 3.20)
 project(quadrature LANGUAGES CXX)
 
+function(target_enable_project_warnings target)
+    if(NOT TARGET "${target}")
+        message(FATAL_ERROR "target_enable_project_warnings called for unknown target: ${target}")
+    endif()
+
+    target_compile_options("${target}" PRIVATE
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wall>"
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wextra>"
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wpedantic>"
+    )
+endfunction()
+
 set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_STANDARD_REQUIRED YES)
 set(CMAKE_CXX_EXTENSIONS NO)
 
-add_compile_options(-Wall -Wextra -Wpedantic)
-
 add_executable(quad.exe
     main_quad.cpp simpson_quad.cpp gaussian_quad.cpp)
+target_enable_project_warnings(quad.exe)

--- a/source-code/Classes/QuadratureImplementations/Quadrature_duck_typing/CMakeLists.txt
+++ b/source-code/Classes/QuadratureImplementations/Quadrature_duck_typing/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.20)
 
 project(duck_typing_quadrature LANGUAGES CXX)
 

--- a/source-code/Classes/QuadratureImplementations/Quadrature_duck_typing/CMakeLists.txt
+++ b/source-code/Classes/QuadratureImplementations/Quadrature_duck_typing/CMakeLists.txt
@@ -2,6 +2,18 @@ cmake_minimum_required(VERSION 3.14)
 
 project(duck_typing_quadrature LANGUAGES CXX)
 
+function(target_enable_project_warnings target)
+    if(NOT TARGET "${target}")
+        message(FATAL_ERROR "target_enable_project_warnings called for unknown target: ${target}")
+    endif()
+
+    target_compile_options("${target}" PRIVATE
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wall>"
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wextra>"
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wpedantic>"
+    )
+endfunction()
+
 add_executable(quad.exe)
 
 target_sources(
@@ -13,7 +25,7 @@ target_sources(
 )
 
 target_compile_features(quad.exe PRIVATE cxx_std_14)
-target_compile_options(quad.exe PRIVATE -Wall -Wextra)
+target_enable_project_warnings(quad.exe)
 
 # Match Makefile defaults: debug symbols and O2 optimization.
 target_compile_options(quad.exe PRIVATE -g -O2)

--- a/source-code/Classes/QuadratureImplementations/Quadrature_duck_typing_template/CMakeLists.txt
+++ b/source-code/Classes/QuadratureImplementations/Quadrature_duck_typing_template/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.20)
 
 project(duck_typing_quadrature_template LANGUAGES CXX)
 

--- a/source-code/Classes/QuadratureImplementations/Quadrature_duck_typing_template/CMakeLists.txt
+++ b/source-code/Classes/QuadratureImplementations/Quadrature_duck_typing_template/CMakeLists.txt
@@ -2,6 +2,18 @@ cmake_minimum_required(VERSION 3.14)
 
 project(duck_typing_quadrature_template LANGUAGES CXX)
 
+function(target_enable_project_warnings target)
+    if(NOT TARGET "${target}")
+        message(FATAL_ERROR "target_enable_project_warnings called for unknown target: ${target}")
+    endif()
+
+    target_compile_options("${target}" PRIVATE
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wall>"
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wextra>"
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wpedantic>"
+    )
+endfunction()
+
 add_executable(quad.exe)
 
 target_sources(
@@ -12,5 +24,6 @@ target_sources(
 )
 
 target_compile_features(quad.exe PRIVATE cxx_std_14)
-target_compile_options(quad.exe PRIVATE -Wall -Wextra -g -O2)
+target_compile_options(quad.exe PRIVATE -g -O2)
+target_enable_project_warnings(quad.exe)
 target_link_libraries(quad.exe PRIVATE m)

--- a/source-code/Classes/Stats/CMakeLists.txt
+++ b/source-code/Classes/Stats/CMakeLists.txt
@@ -1,6 +1,19 @@
 cmake_minimum_required(VERSION 3.20)
 
 project(stats LANGUAGES CXX)
+
+function(target_enable_project_warnings target)
+    if(NOT TARGET "${target}")
+        message(FATAL_ERROR "target_enable_project_warnings called for unknown target: ${target}")
+    endif()
+
+    target_compile_options("${target}" PRIVATE
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wall>"
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wextra>"
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wpedantic>"
+    )
+endfunction()
+
 include(CTest)
 enable_testing()
 
@@ -14,7 +27,7 @@ add_executable(stats.exe
     stats.cpp
 )
 
-target_compile_options(stats.exe PRIVATE -Wall -Wextra -Wpedantic)
+target_enable_project_warnings(stats.exe)
   
 # Add exception tests (requires BUILD_TESTING enabled)
 if(BUILD_TESTING)
@@ -23,7 +36,7 @@ if(BUILD_TESTING)
         simple_stats.cpp
         stats.cpp
     )
-    target_compile_options(stats_exceptions_test.exe PRIVATE -Wall -Wextra -Wpedantic)
+target_enable_project_warnings(stats_exceptions_test.exe)
     add_test(NAME StatsExceptionTests
              COMMAND stats_exceptions_test.exe)
 
@@ -33,7 +46,7 @@ if(BUILD_TESTING)
         simple_stats.cpp
         stats.cpp
     )
-    target_compile_options(stats_values_test.exe PRIVATE -Wall -Wextra -Wpedantic)
+target_enable_project_warnings(stats_values_test.exe)
     add_test(NAME StatsValuesTests
              COMMAND stats_values_test.exe)
 endif()

--- a/source-code/Conan/CMakeLists.txt
+++ b/source-code/Conan/CMakeLists.txt
@@ -1,7 +1,19 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.20)
 project(args_test LANGUAGES CXX)
 
-set(CMAKE_CXX_COMPILER  g++)
+
+function(target_enable_project_warnings target)
+    if(NOT TARGET "${target}")
+        message(FATAL_ERROR "target_enable_project_warnings called for unknown target: ${target}")
+    endif()
+
+    target_compile_options("${target}" PRIVATE
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wall>"
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wextra>"
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wpedantic>"
+    )
+endfunction()
+
 set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED YES)
 set(CMAKE_CXX_EXTENSIONS NO)
@@ -10,4 +22,5 @@ include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
 conan_basic_setup()
 
 add_executable(generate_gaussian.exe generate_gaussian.cpp)
+target_enable_project_warnings(generate_gaussian.exe)
 target_link_libraries(generate_gaussian.exe ${CONAN_LIBS})

--- a/source-code/Containers/associative/CMakeLists.txt
+++ b/source-code/Containers/associative/CMakeLists.txt
@@ -2,11 +2,22 @@ cmake_minimum_required(VERSION 3.20)
 
 project(associative_examples LANGUAGES CXX)
 
+function(target_enable_project_warnings target)
+    if(NOT TARGET "${target}")
+        message(FATAL_ERROR "target_enable_project_warnings called for unknown target: ${target}")
+    endif()
+
+    target_compile_options("${target}" PRIVATE
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wall>"
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wextra>"
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wpedantic>"
+    )
+endfunction()
+
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
-set(COMMON_FLAGS -Wall -Wextra -Wpedantic)
 
 set(ASSOCIATIVE_EXAMPLES
     aggregate_data
@@ -19,5 +30,5 @@ set(ASSOCIATIVE_EXAMPLES
 
 foreach(app ${ASSOCIATIVE_EXAMPLES})
     add_executable(${app}.exe ${app}.cpp)
-    target_compile_options(${app}.exe PRIVATE ${COMMON_FLAGS})
+target_enable_project_warnings(${app}.exe)
 endforeach()

--- a/source-code/Containers/numeric/CMakeLists.txt
+++ b/source-code/Containers/numeric/CMakeLists.txt
@@ -2,11 +2,22 @@ cmake_minimum_required(VERSION 3.20)
 
 project(numeric_examples LANGUAGES CXX)
 
+function(target_enable_project_warnings target)
+    if(NOT TARGET "${target}")
+        message(FATAL_ERROR "target_enable_project_warnings called for unknown target: ${target}")
+    endif()
+
+    target_compile_options("${target}" PRIVATE
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wall>"
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wextra>"
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wpedantic>"
+    )
+endfunction()
+
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
-set(COMMON_FLAGS -Wall -Wextra -Wpedantic)
 set(COMMON_LIBS m)
 
 set(NUMERIC_EXAMPLES
@@ -19,6 +30,6 @@ set(NUMERIC_EXAMPLES
 
 foreach(app ${NUMERIC_EXAMPLES})
     add_executable(${app}.exe ${app}.cpp)
-    target_compile_options(${app}.exe PRIVATE ${COMMON_FLAGS})
+target_enable_project_warnings(${app}.exe)
     target_link_libraries(${app}.exe PRIVATE ${COMMON_LIBS})
 endforeach()

--- a/source-code/Containers/sequence/CMakeLists.txt
+++ b/source-code/Containers/sequence/CMakeLists.txt
@@ -2,11 +2,22 @@ cmake_minimum_required(VERSION 3.20)
 
 project(sequence_examples LANGUAGES CXX)
 
+function(target_enable_project_warnings target)
+    if(NOT TARGET "${target}")
+        message(FATAL_ERROR "target_enable_project_warnings called for unknown target: ${target}")
+    endif()
+
+    target_compile_options("${target}" PRIVATE
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wall>"
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wextra>"
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wpedantic>"
+    )
+endfunction()
+
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
-set(COMMON_FLAGS -Wall -Wextra -Wpedantic)
 
 set(SEQUENCE_EXAMPLES
     array_sum_squares
@@ -20,5 +31,5 @@ set(SEQUENCE_EXAMPLES
 
 foreach(app ${SEQUENCE_EXAMPLES})
     add_executable(${app}.exe ${app}.cpp)
-    target_compile_options(${app}.exe PRIVATE ${COMMON_FLAGS})
+target_enable_project_warnings(${app}.exe)
 endforeach()

--- a/source-code/Containers/sliding_window/CMakeLists.txt
+++ b/source-code/Containers/sliding_window/CMakeLists.txt
@@ -2,8 +2,22 @@ cmake_minimum_required(VERSION 3.20)
 
 project(sliding_window LANGUAGES CXX)
 
+
+function(target_enable_project_warnings target)
+    if(NOT TARGET "${target}")
+        message(FATAL_ERROR "target_enable_project_warnings called for unknown target: ${target}")
+    endif()
+
+    target_compile_options("${target}" PRIVATE
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wall>"
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wextra>"
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wpedantic>"
+    )
+endfunction()
+
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED YES)
 set(CMAKE_CXX_EXTENSIONS NO)
 
 add_executable(window.exe sliding_window_main.cpp)
+target_enable_project_warnings(window.exe)

--- a/source-code/Containers/stacks_queues/CMakeLists.txt
+++ b/source-code/Containers/stacks_queues/CMakeLists.txt
@@ -2,17 +2,28 @@ cmake_minimum_required(VERSION 3.20)
 
 project(stacks_queues_examples LANGUAGES CXX)
 
+function(target_enable_project_warnings target)
+    if(NOT TARGET "${target}")
+        message(FATAL_ERROR "target_enable_project_warnings called for unknown target: ${target}")
+    endif()
+
+    target_compile_options("${target}" PRIVATE
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wall>"
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wextra>"
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wpedantic>"
+    )
+endfunction()
+
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
-set(COMMON_FLAGS -Wall -Wextra -Wpedantic)
 
 add_executable(rpn_calc.exe rpn_calc.cpp)
-target_compile_options(rpn_calc.exe PRIVATE ${COMMON_FLAGS})
+target_enable_project_warnings(rpn_calc.exe)
 
 add_executable(task_queue.exe task_queue.cpp)
-target_compile_options(task_queue.exe PRIVATE ${COMMON_FLAGS})
+target_enable_project_warnings(task_queue.exe)
 
 add_executable(er_triage.exe er_triage.cpp)
-target_compile_options(er_triage.exe PRIVATE ${COMMON_FLAGS})
+target_enable_project_warnings(er_triage.exe)

--- a/source-code/Containers/stacks_queues/diffusion/CMakeLists.txt
+++ b/source-code/Containers/stacks_queues/diffusion/CMakeLists.txt
@@ -2,16 +2,27 @@ cmake_minimum_required(VERSION 3.20)
 
 project(diffusion LANGUAGES CXX)
 
+function(target_enable_project_warnings target)
+    if(NOT TARGET "${target}")
+        message(FATAL_ERROR "target_enable_project_warnings called for unknown target: ${target}")
+    endif()
+
+    target_compile_options("${target}" PRIVATE
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wall>"
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wextra>"
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wpedantic>"
+    )
+endfunction()
+
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
-set(COMMON_FLAGS -Wall -Wextra -Wpedantic)
 set(COMMON_LIBS m)
 
 add_executable(diffusion.exe
     diffusion_main.cpp
     diffusion_system.cpp
 )
-target_compile_options(diffusion.exe PRIVATE ${COMMON_FLAGS})
+target_enable_project_warnings(diffusion.exe)
 target_link_libraries(diffusion.exe PRIVATE ${COMMON_LIBS})

--- a/source-code/DesignPatterns/BuilderPattern/CMakeLists.txt
+++ b/source-code/DesignPatterns/BuilderPattern/CMakeLists.txt
@@ -1,6 +1,18 @@
 cmake_minimum_required(VERSION 3.20)
 project(builder_pattern_examples LANGUAGES CXX)
 
+function(target_enable_project_warnings target)
+    if(NOT TARGET "${target}")
+        message(FATAL_ERROR "target_enable_project_warnings called for unknown target: ${target}")
+    endif()
+
+    target_compile_options("${target}" PRIVATE
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wall>"
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wextra>"
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wpedantic>"
+    )
+endfunction()
+
 set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
@@ -11,4 +23,4 @@ add_executable(
     rng_builder.cpp
     rng_runner.cpp
 )
-target_compile_options(rng_runner.exe PRIVATE -Wall -Wextra)
+target_enable_project_warnings(rng_runner.exe)

--- a/source-code/DesignPatterns/CRTP/CMakeLists.txt
+++ b/source-code/DesignPatterns/CRTP/CMakeLists.txt
@@ -2,6 +2,18 @@ cmake_minimum_required(VERSION 3.20)
 
 project(simulations LANGUAGES CXX)
 
+function(target_enable_project_warnings target)
+    if(NOT TARGET "${target}")
+        message(FATAL_ERROR "target_enable_project_warnings called for unknown target: ${target}")
+    endif()
+
+    target_compile_options("${target}" PRIVATE
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wall>"
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wextra>"
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wpedantic>"
+    )
+endfunction()
+
 set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
@@ -13,6 +25,5 @@ set(SIMULATIONS
 foreach(SIMULATION ${SIMULATIONS})
     add_executable(${SIMULATION}.exe
         main_${SIMULATION}.cpp)
-    target_compile_options(${SIMULATION}.exe
-        PRIVATE -Wall -Wextra -Wpedantic)
+target_enable_project_warnings(${SIMULATION}.exe)
 endforeach()

--- a/source-code/DesignPatterns/CellularAutomata/CMakeLists.txt
+++ b/source-code/DesignPatterns/CellularAutomata/CMakeLists.txt
@@ -2,6 +2,18 @@ cmake_minimum_required(VERSION 3.20)
 
 project(cellular_automata LANGUAGES CXX)
 
+function(target_enable_project_warnings target)
+    if(NOT TARGET "${target}")
+        message(FATAL_ERROR "target_enable_project_warnings called for unknown target: ${target}")
+    endif()
+
+    target_compile_options("${target}" PRIVATE
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wall>"
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wextra>"
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wpedantic>"
+    )
+endfunction()
+
 if(POLICY CMP0167)
     cmake_policy(SET CMP0167 NEW)
 endif()
@@ -23,5 +35,5 @@ add_executable(cellular_automata.exe
     utils.cpp
     visualization_runner.cpp
     main.cpp)
-target_compile_options(cellular_automata.exe PRIVATE -Wall -Wextra -Wpedantic)
+target_enable_project_warnings(cellular_automata.exe)
 target_link_libraries(cellular_automata.exe PRIVATE Boost::program_options)

--- a/source-code/DesignPatterns/CellularAutomata/add-dynamics/CMakeLists.txt
+++ b/source-code/DesignPatterns/CellularAutomata/add-dynamics/CMakeLists.txt
@@ -2,6 +2,18 @@ cmake_minimum_required(VERSION 3.20)
 
 project(cellular_automata LANGUAGES CXX)
 
+function(target_enable_project_warnings target)
+    if(NOT TARGET "${target}")
+        message(FATAL_ERROR "target_enable_project_warnings called for unknown target: ${target}")
+    endif()
+
+    target_compile_options("${target}" PRIVATE
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wall>"
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wextra>"
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wpedantic>"
+    )
+endfunction()
+
 if(POLICY CMP0167)
   cmake_policy(SET CMP0167 NEW)
 endif()
@@ -24,5 +36,5 @@ add_executable(cellular_automata.exe
     utils.cpp
     visualization_runner.cpp
     main.cpp)
-target_compile_options(cellular_automata.exe PRIVATE -Wall -Wextra -Wpedantic)
+target_enable_project_warnings(cellular_automata.exe)
 target_link_libraries(cellular_automata.exe PRIVATE Boost::program_options)

--- a/source-code/DesignPatterns/FactoryPattern/FunctionFactory/CMakeLists.txt
+++ b/source-code/DesignPatterns/FactoryPattern/FunctionFactory/CMakeLists.txt
@@ -2,6 +2,18 @@ cmake_minimum_required(VERSION 3.20)
 
 project(function_factory LANGUAGES CXX)
 
+function(target_enable_project_warnings target)
+    if(NOT TARGET "${target}")
+        message(FATAL_ERROR "target_enable_project_warnings called for unknown target: ${target}")
+    endif()
+
+    target_compile_options("${target}" PRIVATE
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wall>"
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wextra>"
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wpedantic>"
+    )
+endfunction()
+
 set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
@@ -11,8 +23,7 @@ find_package(Boost REQUIRED COMPONENTS program_options)
 add_executable(function_factory.exe
     main.cpp
 )
-target_compile_options(function_factory.exe
-    PRIVATE -Wall -Wextra -Wpedantic)
+target_enable_project_warnings(function_factory.exe)
 target_include_directories(function_factory.exe
     PRIVATE Boost::Boost)
 target_link_libraries(function_factory.exe

--- a/source-code/DesignPatterns/FactoryPattern/RandomCircleFactory/CMakeLists.txt
+++ b/source-code/DesignPatterns/FactoryPattern/RandomCircleFactory/CMakeLists.txt
@@ -1,6 +1,18 @@
 cmake_minimum_required(VERSION 3.20)
 project(random_circle_factory LANGUAGES CXX)
 
+function(target_enable_project_warnings target)
+    if(NOT TARGET "${target}")
+        message(FATAL_ERROR "target_enable_project_warnings called for unknown target: ${target}")
+    endif()
+
+    target_compile_options("${target}" PRIVATE
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wall>"
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wextra>"
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wpedantic>"
+    )
+endfunction()
+
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
@@ -14,7 +26,7 @@ add_executable(
 add_executable(circle_overlap.exe circle.cpp circle_overlap.cpp)
 
 foreach(app random_circles.exe circle_overlap.exe)
-    target_compile_options(${app} PRIVATE -Wall -Wextra)
+target_enable_project_warnings(${app})
     target_link_libraries(${app} PRIVATE m)
 endforeach()
 

--- a/source-code/DesignPatterns/StrategyPattern/CMakeLists.txt
+++ b/source-code/DesignPatterns/StrategyPattern/CMakeLists.txt
@@ -1,6 +1,18 @@
 cmake_minimum_required(VERSION 3.20)
 project(strategy_pattern_examples LANGUAGES CXX)
 
+function(target_enable_project_warnings target)
+    if(NOT TARGET "${target}")
+        message(FATAL_ERROR "target_enable_project_warnings called for unknown target: ${target}")
+    endif()
+
+    target_compile_options("${target}" PRIVATE
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wall>"
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wextra>"
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wpedantic>"
+    )
+endfunction()
+
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
@@ -11,4 +23,4 @@ add_executable(
     cycle_finder.cpp
     main.cpp
 )
-target_compile_options(cellular_automaton.exe PRIVATE -Wall -Wextra -Wpedantic)
+target_enable_project_warnings(cellular_automaton.exe)

--- a/source-code/Eigen/CMakeLists.txt
+++ b/source-code/Eigen/CMakeLists.txt
@@ -2,6 +2,19 @@ cmake_minimum_required(VERSION 3.20)
 
 project(eigen LANGUAGES CXX)
 
+
+function(target_enable_project_warnings target)
+    if(NOT TARGET "${target}")
+        message(FATAL_ERROR "target_enable_project_warnings called for unknown target: ${target}")
+    endif()
+
+    target_compile_options("${target}" PRIVATE
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wall>"
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wextra>"
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wpedantic>"
+    )
+endfunction()
+
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
@@ -14,6 +27,7 @@ set(APPLICATIONS
 foreach(APP ${APPLICATIONS})
     add_executable(${APP}.exe
         ${APP}.cpp)
+    target_enable_project_warnings(${APP}.exe)
     target_include_directories(${APP}.exe
         PRIVATE ${EIGEN_INCLUDE_DIR})
 endforeach()

--- a/source-code/Eigen/Mkl/CMakeLists.txt
+++ b/source-code/Eigen/Mkl/CMakeLists.txt
@@ -1,6 +1,18 @@
 cmake_minimum_required(VERSION 3.20)
 project(eigen_mkl_example LANGUAGES CXX)
 
+function(target_enable_project_warnings target)
+    if(NOT TARGET "${target}")
+        message(FATAL_ERROR "target_enable_project_warnings called for unknown target: ${target}")
+    endif()
+
+    target_compile_options("${target}" PRIVATE
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wall>"
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wextra>"
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wpedantic>"
+    )
+endfunction()
+
 set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
@@ -14,7 +26,7 @@ endif()
 set(MKLROOT_DIR $ENV{MKLROOT})
 
 add_executable(matrix_product.exe matrix_product.cpp)
-target_compile_options(matrix_product.exe PRIVATE -Wall -Wextra)
+target_enable_project_warnings(matrix_product.exe)
 target_include_directories(
     matrix_product.exe PRIVATE
     ${EIGEN3_INCLUDE_DIR}

--- a/source-code/Eigen/StringAlignment/CMakeLists.txt
+++ b/source-code/Eigen/StringAlignment/CMakeLists.txt
@@ -1,6 +1,18 @@
 cmake_minimum_required(VERSION 3.20)
 project(string_alignment_example LANGUAGES CXX)
 
+function(target_enable_project_warnings target)
+    if(NOT TARGET "${target}")
+        message(FATAL_ERROR "target_enable_project_warnings called for unknown target: ${target}")
+    endif()
+
+    target_compile_options("${target}" PRIVATE
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wall>"
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wextra>"
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wpedantic>"
+    )
+endfunction()
+
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
@@ -12,6 +24,6 @@ add_executable(
     main.cpp
     string_aligner.cpp
 )
-target_compile_options(string_align.exe PRIVATE -Wall -Wextra -Wpedantic)
+target_enable_project_warnings(string_align.exe)
 target_include_directories(string_align.exe PRIVATE ${EIGEN3_INCLUDE_DIR})
 target_link_libraries(string_align.exe PRIVATE m)

--- a/source-code/ErrorHandling/Exceptions/CMakeLists.txt
+++ b/source-code/ErrorHandling/Exceptions/CMakeLists.txt
@@ -2,9 +2,24 @@ cmake_minimum_required(VERSION 3.20)
 
 project(exceptions LANGUAGES CXX)
 
+
+function(target_enable_project_warnings target)
+    if(NOT TARGET "${target}")
+        message(FATAL_ERROR "target_enable_project_warnings called for unknown target: ${target}")
+    endif()
+
+    target_compile_options("${target}" PRIVATE
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wall>"
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wextra>"
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wpedantic>"
+    )
+endfunction()
+
 set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
 add_executable(fac.exe fac.cpp)
+target_enable_project_warnings(fac.exe)
 add_executable(fac_custom_exceptions.exe fac_custom_exceptions.cpp)
+target_enable_project_warnings(fac_custom_exceptions.exe)

--- a/source-code/ErrorHandling/Expected/CMakeLists.txt
+++ b/source-code/ErrorHandling/Expected/CMakeLists.txt
@@ -2,8 +2,22 @@ cmake_minimum_required(VERSION 3.20)
 
 project(expected LANGUAGES CXX)
 
+
+function(target_enable_project_warnings target)
+    if(NOT TARGET "${target}")
+        message(FATAL_ERROR "target_enable_project_warnings called for unknown target: ${target}")
+    endif()
+
+    target_compile_options("${target}" PRIVATE
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wall>"
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wextra>"
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wpedantic>"
+    )
+endfunction()
+
 set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
 add_executable(fac.exe fac.cpp)
+target_enable_project_warnings(fac.exe)

--- a/source-code/ErrorHandling/MemoryLeak/CMakeLists.txt
+++ b/source-code/ErrorHandling/MemoryLeak/CMakeLists.txt
@@ -1,6 +1,18 @@
 cmake_minimum_required(VERSION 3.20)
 project(memory_leak_examples LANGUAGES CXX)
 
+function(target_enable_project_warnings target)
+    if(NOT TARGET "${target}")
+        message(FATAL_ERROR "target_enable_project_warnings called for unknown target: ${target}")
+    endif()
+
+    target_compile_options("${target}" PRIVATE
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wall>"
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wextra>"
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wpedantic>"
+    )
+endfunction()
+
 set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
@@ -9,6 +21,6 @@ set(APPL memory_leak memory_leak_fixed)
 
 foreach(app ${APPL})
     add_executable(${app}.exe ${app}.cpp)
-    target_compile_options(${app}.exe PRIVATE -Wall -Wextra)
+target_enable_project_warnings(${app}.exe)
     target_link_libraries(${app}.exe PRIVATE m)
 endforeach()

--- a/source-code/Functional/CMakeLists.txt
+++ b/source-code/Functional/CMakeLists.txt
@@ -2,6 +2,19 @@ cmake_minimum_required(VERSION 3.20)
 
 project(FunctionalAggregate LANGUAGES CXX)
 
+
+function(target_enable_project_warnings target)
+    if(NOT TARGET "${target}")
+        message(FATAL_ERROR "target_enable_project_warnings called for unknown target: ${target}")
+    endif()
+
+    target_compile_options("${target}" PRIVATE
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wall>"
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wextra>"
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wpedantic>"
+    )
+endfunction()
+
 add_executable(aggregate aggregate.cpp)
 
 target_compile_features(aggregate PRIVATE cxx_std_14)
@@ -9,8 +22,6 @@ set_target_properties(aggregate PROPERTIES
   CXX_EXTENSIONS OFF
 )
 
-target_compile_options(aggregate PRIVATE
-  $<$<CXX_COMPILER_ID:GNU,Clang,AppleClang>:-Wall -Wextra>
-)
+target_enable_project_warnings(aggregate)
 
 target_link_libraries(aggregate PRIVATE m)

--- a/source-code/Functional/CountUpGenerator/CMakeLists.txt
+++ b/source-code/Functional/CountUpGenerator/CMakeLists.txt
@@ -1,8 +1,22 @@
 cmake_minimum_required(VERSION 3.20)
 
 project(count_up_generator LANGUAGES CXX)
+
+function(target_enable_project_warnings target)
+    if(NOT TARGET "${target}")
+        message(FATAL_ERROR "target_enable_project_warnings called for unknown target: ${target}")
+    endif()
+
+    target_compile_options("${target}" PRIVATE
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wall>"
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wextra>"
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wpedantic>"
+    )
+endfunction()
+
 set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
 add_executable(count_up.exe count_up.cpp)
+target_enable_project_warnings(count_up.exe)

--- a/source-code/Functional/FibonacciGenerator/CMakeLists.txt
+++ b/source-code/Functional/FibonacciGenerator/CMakeLists.txt
@@ -1,8 +1,22 @@
 cmake_minimum_required(VERSION 3.20)
 
 project(fibonacci_generator LANGUAGES CXX)
+
+function(target_enable_project_warnings target)
+    if(NOT TARGET "${target}")
+        message(FATAL_ERROR "target_enable_project_warnings called for unknown target: ${target}")
+    endif()
+
+    target_compile_options("${target}" PRIVATE
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wall>"
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wextra>"
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wpedantic>"
+    )
+endfunction()
+
 set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
 add_executable(fib.exe fib.cpp)
+target_enable_project_warnings(fib.exe)

--- a/source-code/Functional/IIFE/CMakeLists.txt
+++ b/source-code/Functional/IIFE/CMakeLists.txt
@@ -1,9 +1,20 @@
 cmake_minimum_required(VERSION 3.31)
 project(immediately_invoked_function_expression LANGUAGES CXX)
 
+function(target_enable_project_warnings target)
+    if(NOT TARGET "${target}")
+        message(FATAL_ERROR "target_enable_project_warnings called for unknown target: ${target}")
+    endif()
+
+    target_compile_options("${target}" PRIVATE
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wall>"
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wextra>"
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wpedantic>"
+    )
+endfunction()
+
 add_executable(iife.exe iife.cpp)
 set_target_properties(iife.exe PROPERTIES
     CXX_STANDARD 23
     CXX_STANDARD_REQUIRED YES)
-target_compile_options(iife.exe PRIVATE
-    $<$<NOT:$<CXX_COMPILER_ID:MSVC>>:-Wall -Wextra -Wpedantic>)
+target_enable_project_warnings(iife.exe)

--- a/source-code/Functional/IIFE/CMakeLists.txt
+++ b/source-code/Functional/IIFE/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.31)
+cmake_minimum_required(VERSION 3.20)
 project(immediately_invoked_function_expression LANGUAGES CXX)
 
 function(target_enable_project_warnings target)

--- a/source-code/Functional/Pendulum/CMakeLists.txt
+++ b/source-code/Functional/Pendulum/CMakeLists.txt
@@ -2,6 +2,18 @@ cmake_minimum_required(VERSION 3.20)
 
 project(closures LANGUAGES CXX)
 
+function(target_enable_project_warnings target)
+    if(NOT TARGET "${target}")
+        message(FATAL_ERROR "target_enable_project_warnings called for unknown target: ${target}")
+    endif()
+
+    target_compile_options("${target}" PRIVATE
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wall>"
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wextra>"
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wpedantic>"
+    )
+endfunction()
+
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
@@ -15,6 +27,5 @@ foreach(APP ${APPL})
     add_executable(${APP}.exe
         ${APP}.cpp
         pendulum_utils.cpp)
-    target_compile_options(${APP}.exe
-        PRIVATE -Wall -Wextra -Wpedantic)
+target_enable_project_warnings(${APP}.exe)
 endforeach()

--- a/source-code/Functional/PersistentBinaryTrees/CMakeLists.txt
+++ b/source-code/Functional/PersistentBinaryTrees/CMakeLists.txt
@@ -1,12 +1,23 @@
 cmake_minimum_required(VERSION 3.20)
 project(persistent_binary_search_tree LANGUAGES CXX)
 
+function(target_enable_project_warnings target)
+    if(NOT TARGET "${target}")
+        message(FATAL_ERROR "target_enable_project_warnings called for unknown target: ${target}")
+    endif()
+
+    target_compile_options("${target}" PRIVATE
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wall>"
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wextra>"
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wpedantic>"
+    )
+endfunction()
+
 set(CMAKE_CXX_STANDARD 20)
 set(CMaKE_CXX_STANDARD_REQUIRED YES)
 set(CMAKE_CXX_EXTENSIONS NO)
 
-add_compile_options(-Wall -Wextra -Wpedantic)
-
 add_executable(tree.exe
     main.cpp
     persistent_binary_tree.cpp)
+target_enable_project_warnings(tree.exe)

--- a/source-code/Functional/StreamingData/CMakeLists.txt
+++ b/source-code/Functional/StreamingData/CMakeLists.txt
@@ -1,11 +1,23 @@
 cmake_minimum_required(VERSION 3.0)
 project(stats LANGUAGES CXX)
 
+function(target_enable_project_warnings target)
+    if(NOT TARGET "${target}")
+        message(FATAL_ERROR "target_enable_project_warnings called for unknown target: ${target}")
+    endif()
+
+    target_compile_options("${target}" PRIVATE
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wall>"
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wextra>"
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wpedantic>"
+    )
+endfunction()
+
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED YES)
 set(CMAKE_CXX_GNU_EXTNESIONS NO)
 
-add_compile_options(-Wall -Wextra -Wpedantic)
-
 add_executable(stats_functional.exe main_functional.cpp)
+target_enable_project_warnings(stats_functional.exe)
 add_executable(stats_oo.exe main_oo.cpp)
+target_enable_project_warnings(stats_oo.exe)

--- a/source-code/Functional/StreamingData/CMakeLists.txt
+++ b/source-code/Functional/StreamingData/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.20)
 project(stats LANGUAGES CXX)
 
 function(target_enable_project_warnings target)

--- a/source-code/Functional/StreamingData/CMakeLists.txt
+++ b/source-code/Functional/StreamingData/CMakeLists.txt
@@ -15,7 +15,7 @@ endfunction()
 
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED YES)
-set(CMAKE_CXX_GNU_EXTNESIONS NO)
+set(CMAKE_CXX_EXTENSIONS NO)
 
 add_executable(stats_functional.exe main_functional.cpp)
 target_enable_project_warnings(stats_functional.exe)

--- a/source-code/GeneralUtilities/CMakeLists.txt
+++ b/source-code/GeneralUtilities/CMakeLists.txt
@@ -2,9 +2,24 @@ cmake_minimum_required(VERSION 3.20)
 
 project(general_utilities LANGUAGES CXX)
 
+
+function(target_enable_project_warnings target)
+    if(NOT TARGET "${target}")
+        message(FATAL_ERROR "target_enable_project_warnings called for unknown target: ${target}")
+    endif()
+
+    target_compile_options("${target}" PRIVATE
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wall>"
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wextra>"
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wpedantic>"
+    )
+endfunction()
+
 set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
 add_executable(optional.exe optional.cpp)
+target_enable_project_warnings(optional.exe)
 add_executable(variant_visit.exe variant_visit.cpp)
+target_enable_project_warnings(variant_visit.exe)

--- a/source-code/GrammarFeatures/CMakeLists.txt
+++ b/source-code/GrammarFeatures/CMakeLists.txt
@@ -2,6 +2,18 @@ cmake_minimum_required(VERSION 3.16)
 
 project(grammar_features LANGUAGES CXX)
 
+function(target_enable_project_warnings target)
+    if(NOT TARGET "${target}")
+        message(FATAL_ERROR "target_enable_project_warnings called for unknown target: ${target}")
+    endif()
+
+    target_compile_options("${target}" PRIVATE
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wall>"
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wextra>"
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wpedantic>"
+    )
+endfunction()
+
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
@@ -19,11 +31,5 @@ set_target_properties(
 )
 
 foreach(target if_init.exe struct_initialiation.exe structured_bindings.exe)
-  target_compile_options(
-    ${target}
-    PRIVATE
-      -Wall
-      -Wextra
-      -Wpedantic
-  )
+target_enable_project_warnings(${target})
 endforeach()

--- a/source-code/GrammarFeatures/CMakeLists.txt
+++ b/source-code/GrammarFeatures/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.16)
+cmake_minimum_required(VERSION 3.20)
 
 project(grammar_features LANGUAGES CXX)
 

--- a/source-code/IO/binary_io/CMakeLists.txt
+++ b/source-code/IO/binary_io/CMakeLists.txt
@@ -2,6 +2,29 @@ cmake_minimum_required(VERSION 3.20)
 
 project(binary_io LANGUAGES Fortran CXX)
 
+function(target_enable_project_cxx_warnings target)
+    if(NOT TARGET "${target}")
+        message(FATAL_ERROR "target_enable_project_cxx_warnings called for unknown target: ${target}")
+    endif()
+
+    target_compile_options("${target}" PRIVATE
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wall>"
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wextra>"
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wpedantic>"
+    )
+endfunction()
+
+function(target_enable_project_fortran_warnings target)
+    if(NOT TARGET "${target}")
+        message(FATAL_ERROR "target_enable_project_fortran_warnings called for unknown target: ${target}")
+    endif()
+
+    target_compile_options("${target}" PRIVATE
+        "$<$<COMPILE_LANG_AND_ID:Fortran,GNU>:-Wall>"
+        "$<$<COMPILE_LANG_AND_ID:Fortran,GNU>:-Wextra>"
+    )
+endfunction()
+
 set(CMAKE_Fortran_STANDARD 2008)
 set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
@@ -10,8 +33,8 @@ set(CMAKE_CXX_EXTENSIONS OFF)
 find_package(Boost REQUIRED COMPONENTS program_options)
 
 add_executable(triangular_matrix.exe triangular_matrix.f90)
-target_compile_options(triangular_matrix.exe PRIVATE -Wall -Wextra)
+target_enable_project_fortran_warnings(triangular_matrix.exe)
 
 add_executable(read_triangular_matrix.exe read_triangular_matrix.cpp)
-target_compile_options(read_triangular_matrix.exe PRIVATE -Wall -Wextra)
+target_enable_project_cxx_warnings(read_triangular_matrix.exe)
 target_link_libraries(read_triangular_matrix.exe PRIVATE Boost::program_options)

--- a/source-code/IO/formatting/CMakeLists.txt
+++ b/source-code/IO/formatting/CMakeLists.txt
@@ -2,6 +2,19 @@ cmake_minimum_required(VERSION 3.20)
 
 project(formatting LANGUAGES CXX)
 
+
+function(target_enable_project_warnings target)
+    if(NOT TARGET "${target}")
+        message(FATAL_ERROR "target_enable_project_warnings called for unknown target: ${target}")
+    endif()
+
+    target_compile_options("${target}" PRIVATE
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wall>"
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wextra>"
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wpedantic>"
+    )
+endfunction()
+
 include(CheckIncludeFileCXX)
 
 set(CMAKE_CXX_STANDARD 23)
@@ -11,10 +24,13 @@ set(CMAKE_CXX_EXTENSIONS OFF)
 check_include_file_cxx(print HAVE_PRINT_HEADER)
 
 add_executable(iomanip_formatting.exe iomanip_formatting.cpp)
+target_enable_project_warnings(iomanip_formatting.exe)
 add_executable(std_format.exe std_format.cpp)
+target_enable_project_warnings(std_format.exe)
 
 if(HAVE_PRINT_HEADER)
     add_executable(print_format.exe print_format.cpp)
+    target_enable_project_warnings(print_format.exe)
 else()
     message(STATUS "Skipping print_format.exe because <print> is not available")
 endif()

--- a/source-code/IO/streams/CMakeLists.txt
+++ b/source-code/IO/streams/CMakeLists.txt
@@ -1,12 +1,30 @@
 cmake_minimum_required(VERSION 3.20)
 
 project(streams LANGUAGES CXX)
+
+function(target_enable_project_warnings target)
+    if(NOT TARGET "${target}")
+        message(FATAL_ERROR "target_enable_project_warnings called for unknown target: ${target}")
+    endif()
+
+    target_compile_options("${target}" PRIVATE
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wall>"
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wextra>"
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wpedantic>"
+    )
+endfunction()
+
 set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
 add_executable(csv2tsv.exe csv2tsv.cpp)
+target_enable_project_warnings(csv2tsv.exe)
 add_executable(serialization.exe serialization.cpp)
+target_enable_project_warnings(serialization.exe)
 add_executable(sum.exe sum.cpp)
+target_enable_project_warnings(sum.exe)
 add_executable(aggregate.exe aggregate.cpp)
+target_enable_project_warnings(aggregate.exe)
 add_executable(alternative_io.exe alternative_io.cpp)
+target_enable_project_warnings(alternative_io.exe)

--- a/source-code/Misc/CMakeLists.txt
+++ b/source-code/Misc/CMakeLists.txt
@@ -1,10 +1,21 @@
 cmake_minimum_required(VERSION 3.0)
 project(misc LANGUAGES CXX)
 
+function(target_enable_project_warnings target)
+    if(NOT TARGET "${target}")
+        message(FATAL_ERROR "target_enable_project_warnings called for unknown target: ${target}")
+    endif()
+
+    target_compile_options("${target}" PRIVATE
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wall>"
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wextra>"
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wpedantic>"
+    )
+endfunction()
+
 set(CMAKE_CXX_STANDARD 17)
 set(CMaKE_CXX_STANDARD_REQUIRED YES)
 set(CMAKE_CXX_EXTENSIONS NO)
 
-add_compile_options(-Wall -Wextra -Wpedantic)
-
 add_executable(sieve.exe sieve.cpp)
+target_enable_project_warnings(sieve.exe)

--- a/source-code/Misc/CMakeLists.txt
+++ b/source-code/Misc/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.20)
 project(misc LANGUAGES CXX)
 
 function(target_enable_project_warnings target)

--- a/source-code/Modularity/IncludeGuards/CMakeLists.txt
+++ b/source-code/Modularity/IncludeGuards/CMakeLists.txt
@@ -2,6 +2,19 @@ cmake_minimum_required(VERSION 3.20)
 
 project(IncludeGuards LANGUAGES CXX)
 
+
+function(target_enable_project_warnings target)
+    if(NOT TARGET "${target}")
+        message(FATAL_ERROR "target_enable_project_warnings called for unknown target: ${target}")
+    endif()
+
+    target_compile_options("${target}" PRIVATE
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wall>"
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wextra>"
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wpedantic>"
+    )
+endfunction()
+
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
@@ -11,6 +24,7 @@ add_executable(with_include_guards
     src_with_guards/matrix.cpp
     src_with_guards/utils.cpp
 )
+target_enable_project_warnings(with_include_guards)
 
 target_include_directories(with_include_guards
     PRIVATE
@@ -22,6 +36,7 @@ add_executable(without_include_guards EXCLUDE_FROM_ALL
     src_without_guards/matrix.cpp
     src_without_guards/utils.cpp
 )
+target_enable_project_warnings(without_include_guards)
 
 target_include_directories(without_include_guards
     PRIVATE

--- a/source-code/Modularity/IncludeGuards/src_with_guards/CMakeLists.txt
+++ b/source-code/Modularity/IncludeGuards/src_with_guards/CMakeLists.txt
@@ -2,7 +2,21 @@ cmake_minimum_required(VERSION 3.20)
 
 project(Matrices LANGUAGES CXX)
 
+
+function(target_enable_project_warnings target)
+    if(NOT TARGET "${target}")
+        message(FATAL_ERROR "target_enable_project_warnings called for unknown target: ${target}")
+    endif()
+
+    target_compile_options("${target}" PRIVATE
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wall>"
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wextra>"
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wpedantic>"
+    )
+endfunction()
+
 add_executable(matrices.exe
    matrices.cpp
    matrix.cpp
-   utils.cpp) 
+   utils.cpp)
+target_enable_project_warnings(matrices.exe)

--- a/source-code/Modularity/IncludeGuards/src_without_guards/CMakeLists.txt
+++ b/source-code/Modularity/IncludeGuards/src_without_guards/CMakeLists.txt
@@ -2,7 +2,21 @@ cmake_minimum_required(VERSION 3.20)
 
 project(Matrices LANGUAGES CXX)
 
+
+function(target_enable_project_warnings target)
+    if(NOT TARGET "${target}")
+        message(FATAL_ERROR "target_enable_project_warnings called for unknown target: ${target}")
+    endif()
+
+    target_compile_options("${target}" PRIVATE
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wall>"
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wextra>"
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wpedantic>"
+    )
+endfunction()
+
 add_executable(matrices.exe
    matrices.cpp
    matrix.cpp
-   utils.cpp) 
+   utils.cpp)
+target_enable_project_warnings(matrices.exe)

--- a/source-code/Modularity/Modules/CMakeLists.txt
+++ b/source-code/Modularity/Modules/CMakeLists.txt
@@ -1,10 +1,24 @@
 cmake_minimum_required(VERSION 3.28)
 
 project(cpp_modules LANGUAGES CXX)
+
+function(target_enable_project_warnings target)
+    if(NOT TARGET "${target}")
+        message(FATAL_ERROR "target_enable_project_warnings called for unknown target: ${target}")
+    endif()
+
+    target_compile_options("${target}" PRIVATE
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wall>"
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wextra>"
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wpedantic>"
+    )
+endfunction()
+
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
 add_executable(fib.exe)
+target_enable_project_warnings(fib.exe)
 target_sources(fib.exe PUBLIC main.cpp)
 target_sources(fib.exe PUBLIC FILE_SET appl_modules TYPE CXX_MODULES FILES fib.cppm)

--- a/source-code/Modularity/NamespaceParticles/CMakeLists.txt
+++ b/source-code/Modularity/NamespaceParticles/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.16)
+cmake_minimum_required(VERSION 3.20)
 
 project(namespace_particles LANGUAGES CXX)
 

--- a/source-code/Modularity/NamespaceParticles/CMakeLists.txt
+++ b/source-code/Modularity/NamespaceParticles/CMakeLists.txt
@@ -2,25 +2,32 @@ cmake_minimum_required(VERSION 3.16)
 
 project(namespace_particles LANGUAGES CXX)
 
+
+function(target_enable_project_warnings target)
+    if(NOT TARGET "${target}")
+        message(FATAL_ERROR "target_enable_project_warnings called for unknown target: ${target}")
+    endif()
+
+    target_compile_options("${target}" PRIVATE
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wall>"
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wextra>"
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wpedantic>"
+    )
+endfunction()
+
 set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED YES)
 set(CMAKE_CXX_EXTENSIONS NO)
 
-set(PARTICLES_WARNING_FLAGS
-    $<$<COMPILE_LANG_AND_ID:CXX,Clang,AppleClang,GNU>:-Wall>
-    $<$<COMPILE_LANG_AND_ID:CXX,Clang,AppleClang,GNU>:-Wextra>
-    $<$<COMPILE_LANG_AND_ID:CXX,Clang,AppleClang,GNU>:-Wpedantic>
-)
-
 function(add_particles_executable target_name source_file output_name)
     add_executable(${target_name} ${source_file})
     set_target_properties(${target_name} PROPERTIES OUTPUT_NAME ${output_name})
-    target_compile_options(${target_name} PRIVATE ${PARTICLES_WARNING_FLAGS})
+    target_enable_project_warnings(${target_name})
     target_link_libraries(${target_name} PRIVATE particles_lib m)
 endfunction()
 
 add_library(particles_lib particle.cpp)
-target_compile_options(particles_lib PRIVATE ${PARTICLES_WARNING_FLAGS})
+target_enable_project_warnings(particles_lib)
 
 add_particles_executable(particles particles_main.cpp particles.exe)
 

--- a/source-code/Modularity/ParticlesCMake/CMakeLists.txt
+++ b/source-code/Modularity/ParticlesCMake/CMakeLists.txt
@@ -14,7 +14,7 @@ function(target_enable_project_warnings target)
     )
 endfunction()
 
-set(CMAKE_CXX_LANGUAGE_STANDARD 14)
+set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED YES)
 set(CMAKE_CXX_EXTENSIONS NO)
 

--- a/source-code/Modularity/ParticlesCMake/CMakeLists.txt
+++ b/source-code/Modularity/ParticlesCMake/CMakeLists.txt
@@ -2,10 +2,22 @@ cmake_minimum_required(VERSION 3.20)
 
 project(particles LANGUAGES CXX)
 
+function(target_enable_project_warnings target)
+    if(NOT TARGET "${target}")
+        message(FATAL_ERROR "target_enable_project_warnings called for unknown target: ${target}")
+    endif()
+
+    target_compile_options("${target}" PRIVATE
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wall>"
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wextra>"
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wpedantic>"
+    )
+endfunction()
+
 set(CMAKE_CXX_LANGUAGE_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED YES)
 set(CMAKE_CXX_EXTENSIONS NO)
 
 
 add_executable(particles.exe particle.cpp particles_main.cpp)
-target_compile_options(particles.exe BEFORE PRIVATE -Wall -Wextra -Wpedantic)
+target_enable_project_warnings(particles.exe)

--- a/source-code/Modularity/Stats/CMakeLists.txt
+++ b/source-code/Modularity/Stats/CMakeLists.txt
@@ -1,10 +1,22 @@
 cmake_minimum_required(VERSION 3.20)
 project(modularity_stats_example LANGUAGES CXX)
 
+function(target_enable_project_warnings target)
+    if(NOT TARGET "${target}")
+        message(FATAL_ERROR "target_enable_project_warnings called for unknown target: ${target}")
+    endif()
+
+    target_compile_options("${target}" PRIVATE
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wall>"
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wextra>"
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wpedantic>"
+    )
+endfunction()
+
 set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
 add_executable(stats.exe stats.cpp stats_main.cpp)
-target_compile_options(stats.exe PRIVATE -Wall -Wextra)
+target_enable_project_warnings(stats.exe)
 target_link_libraries(stats.exe PRIVATE m)

--- a/source-code/Numerics/CMakeLists.txt
+++ b/source-code/Numerics/CMakeLists.txt
@@ -1,13 +1,32 @@
 cmake_minimum_required(VERSION 3.20)
 
 project(numerics LANGUAGES CXX)
+
+function(target_enable_project_warnings target)
+    if(NOT TARGET "${target}")
+        message(FATAL_ERROR "target_enable_project_warnings called for unknown target: ${target}")
+    endif()
+
+    target_compile_options("${target}" PRIVATE
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wall>"
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wextra>"
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wpedantic>"
+    )
+endfunction()
+
 set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
 add_executable(complex.exe complex.cpp)
+target_enable_project_warnings(complex.exe)
 add_executable(julia.exe julia.cpp)
+target_enable_project_warnings(julia.exe)
 add_executable(limits.exe limits.cpp)
+target_enable_project_warnings(limits.exe)
 add_executable(numbers_pi_versus_M_PI.exe numbers_pi_versus_M_PI.cpp)
+target_enable_project_warnings(numbers_pi_versus_M_PI.exe)
 add_executable(random.exe random.cpp)
+target_enable_project_warnings(random.exe)
 add_executable(multiple_distr.exe multiple_distr.cpp)
+target_enable_project_warnings(multiple_distr.exe)

--- a/source-code/ParallelExecution/CMakeLists.txt
+++ b/source-code/ParallelExecution/CMakeLists.txt
@@ -1,43 +1,59 @@
 cmake_minimum_required(VERSION 3.0)
 project(parallel_algorithms LANGUAGES CXX)
 
+function(target_enable_project_warnings target)
+    if(NOT TARGET "${target}")
+        message(FATAL_ERROR "target_enable_project_warnings called for unknown target: ${target}")
+    endif()
+
+    target_compile_options("${target}" PRIVATE
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wall>"
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wextra>"
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wpedantic>"
+    )
+endfunction()
+
 set(CMAKE_CXX_STANDARD 20)
 set(CMaKE_CXX_STANDARD_REQUIRED YES)
 set(CMAKE_CXX_EXTENSIONS NO)
-
-add_compile_options(-Wall -Wextra -Wpedantic)
 
 find_package(TBB REQUIRED)
 
 add_executable(no_policy.exe
     main_no_policy.cpp
     data.cpp)
+target_enable_project_warnings(no_policy.exe)
 target_link_libraries(no_policy.exe PRIVATE TBB::tbb)
 
 add_executable(seq.exe
     main_seq.cpp
     data.cpp)
+target_enable_project_warnings(seq.exe)
 target_link_libraries(seq.exe PRIVATE TBB::tbb)
 
 add_executable(par.exe
     main_par.cpp
     data.cpp)
+target_enable_project_warnings(par.exe)
 target_link_libraries(par.exe PRIVATE TBB::tbb)
 
 add_executable(transform_seq.exe
     main_transform_seq.cpp
     data.cpp
     functions.cpp)
+target_enable_project_warnings(transform_seq.exe)
 target_link_libraries(transform_seq.exe PRIVATE TBB::tbb)
 
 add_executable(transform_par.exe
     main_transform_par.cpp
     data.cpp
     functions.cpp)
+target_enable_project_warnings(transform_par.exe)
 target_link_libraries(transform_par.exe PRIVATE TBB::tbb)
 
 add_executable(transform_par_unseq.exe
     main_transform_par_unseq.cpp
     data.cpp
     functions.cpp)
+target_enable_project_warnings(transform_par_unseq.exe)
 target_link_libraries(transform_par_unseq.exe PRIVATE TBB::tbb)

--- a/source-code/ParallelExecution/CMakeLists.txt
+++ b/source-code/ParallelExecution/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.20)
 project(parallel_algorithms LANGUAGES CXX)
 
 function(target_enable_project_warnings target)

--- a/source-code/Pointers/CMakeLists.txt
+++ b/source-code/Pointers/CMakeLists.txt
@@ -1,15 +1,28 @@
 cmake_minimum_required(VERSION 3.20)
 project(pointers LANGUAGES CXX)
 
+function(target_enable_project_warnings target)
+    if(NOT TARGET "${target}")
+        message(FATAL_ERROR "target_enable_project_warnings called for unknown target: ${target}")
+    endif()
+
+    target_compile_options("${target}" PRIVATE
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wall>"
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wextra>"
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wpedantic>"
+    )
+endfunction()
+
 set(CMAKE_CXX_STANDARD 17)
 set(CMaKE_CXX_STANDARD_REQUIRED YES)
 set(CMAKE_CXX_EXTENSIONS NO)
 
-add_compile_options(-Wall -Wextra -Wpedantic)
-
 add_executable(runtime_vs_compile_time.exe
     runtime_vs_compile_time.cpp)
+target_enable_project_warnings(runtime_vs_compile_time.exe)
 add_executable(pointers_vs_references.exe
     pointers_vs_references.cpp)
+target_enable_project_warnings(pointers_vs_references.exe)
 add_executable(const_and_pointers.exe
     const_and_pointers.cpp)
+target_enable_project_warnings(const_and_pointers.exe)

--- a/source-code/Pointers/DoubleLinkedList/CMakeLists.txt
+++ b/source-code/Pointers/DoubleLinkedList/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.20)
 
 project(DoubleLinkedList LANGUAGES CXX)
 

--- a/source-code/Pointers/DoubleLinkedList/CMakeLists.txt
+++ b/source-code/Pointers/DoubleLinkedList/CMakeLists.txt
@@ -1,10 +1,7 @@
 cmake_minimum_required(VERSION 3.0)
 project(DoubleLinkedList LANGUAGES CXX)
-
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_STANDARD_REQUIRED YES)
 set(CMAKE_CXX_EXTENSIONS NO)
-
-add_compile_options(-Wall -Wextra -Wpedantic -g)
 
 add_subdirectory(src)

--- a/source-code/Pointers/DoubleLinkedList/CMakeLists.txt
+++ b/source-code/Pointers/DoubleLinkedList/CMakeLists.txt
@@ -1,7 +1,9 @@
 cmake_minimum_required(VERSION 3.0)
+
 project(DoubleLinkedList LANGUAGES CXX)
+
 set(CMAKE_CXX_STANDARD 17)
-set(CMAKE_STANDARD_REQUIRED YES)
+set(CMAKE_CXX_STANDARD_REQUIRED YES)
 set(CMAKE_CXX_EXTENSIONS NO)
 
 add_subdirectory(src)

--- a/source-code/Pointers/DoubleLinkedList/src/CMakeLists.txt
+++ b/source-code/Pointers/DoubleLinkedList/src/CMakeLists.txt
@@ -1,1 +1,15 @@
+function(target_enable_project_warnings target)
+    if(NOT TARGET "${target}")
+        message(FATAL_ERROR "target_enable_project_warnings called for unknown target: ${target}")
+    endif()
+
+    target_compile_options("${target}" PRIVATE
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wall>"
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wextra>"
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wpedantic>"
+    )
+endfunction()
+
 add_executable(linked_list.exe main.cpp)
+target_compile_options(linked_list.exe PRIVATE -g)
+target_enable_project_warnings(linked_list.exe)

--- a/source-code/Pointers/SharedPointers/CMakeLists.txt
+++ b/source-code/Pointers/SharedPointers/CMakeLists.txt
@@ -1,12 +1,23 @@
 cmake_minimum_required(VERSION 3.0)
 project(shared_pointers LANGUAGES CXX)
 
+function(target_enable_project_warnings target)
+    if(NOT TARGET "${target}")
+        message(FATAL_ERROR "target_enable_project_warnings called for unknown target: ${target}")
+    endif()
+
+    target_compile_options("${target}" PRIVATE
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wall>"
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wextra>"
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wpedantic>"
+    )
+endfunction()
+
 set(CMAKE_CXX_STANDARD 20)
 set(CMaKE_CXX_STANDARD_REQUIRED YES)
 set(CMAKE_CXX_EXTENSIONS NO)
 
-add_compile_options(-Wall -Wextra -Wpedantic)
-
 add_executable(linked_list.exe
     main.cpp
     linked_list.cpp)
+target_enable_project_warnings(linked_list.exe)

--- a/source-code/Pointers/SharedPointers/CMakeLists.txt
+++ b/source-code/Pointers/SharedPointers/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.20)
 project(shared_pointers LANGUAGES CXX)
 
 function(target_enable_project_warnings target)

--- a/source-code/Pointers/Tree/CMakeLists.txt
+++ b/source-code/Pointers/Tree/CMakeLists.txt
@@ -1,12 +1,25 @@
 cmake_minimum_required(VERSION 3.0)
 project(trees LANGUAGES CXX)
 
+function(target_enable_project_warnings target)
+    if(NOT TARGET "${target}")
+        message(FATAL_ERROR "target_enable_project_warnings called for unknown target: ${target}")
+    endif()
+
+    target_compile_options("${target}" PRIVATE
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wall>"
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wextra>"
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wpedantic>"
+    )
+endfunction()
+
 set(CMAKE_CXX_STANDARD 17)
 set(CMaKE_CXX_STANDARD_REQUIRED YES)
 set(CMAKE_CXX_EXTENSIONS NO)
 
-add_compile_options(-Wall -Wextra -Wpedantic)
-
 add_executable(tree.exe tree.cpp)
+target_enable_project_warnings(tree.exe)
 add_executable(tree_uptr.exe tree_uptr.cpp)
+target_enable_project_warnings(tree_uptr.exe)
 add_executable(tree_sptr.exe tree_sptr.cpp)
+target_enable_project_warnings(tree_sptr.exe)

--- a/source-code/Pointers/Tree/CMakeLists.txt
+++ b/source-code/Pointers/Tree/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.20)
 project(trees LANGUAGES CXX)
 
 function(target_enable_project_warnings target)

--- a/source-code/Random/CMakeLists.txt
+++ b/source-code/Random/CMakeLists.txt
@@ -2,12 +2,21 @@ cmake_minimum_required(VERSION 3.20)
 
 project(random_values LANGUAGES CXX)
 
+function(target_enable_project_warnings target)
+    if(NOT TARGET "${target}")
+        message(FATAL_ERROR "target_enable_project_warnings called for unknown target: ${target}")
+    endif()
+
+    target_compile_options("${target}" PRIVATE
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wall>"
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wextra>"
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wpedantic>"
+    )
+endfunction()
+
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
-
-# Compiler flags matching Makefile: -O2, -g, -Wall, -Wextra, -Wpedantic
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O2 -g -Wall -Wextra -Wpedantic")
 
 # List of executables and their source files
 set(APPLICATIONS
@@ -18,6 +27,6 @@ set(APPLICATIONS
 
 foreach(appl IN LISTS APPLICATIONS)
     add_executable(${appl}.exe ${appl}.cpp)
-    target_compile_options(${appl}.exe
-        PRIVATE -Wall -Wextra -Wpedantic)
+    target_compile_options(${appl}.exe PRIVATE -O2 -g)
+    target_enable_project_warnings(${appl}.exe)
 endforeach()

--- a/source-code/Ranges/CMakeLists.txt
+++ b/source-code/Ranges/CMakeLists.txt
@@ -1,23 +1,40 @@
 cmake_minimum_required(VERSION 3.20)
 project(ranges LANGUAGES CXX)
 
+function(target_enable_project_warnings target)
+    if(NOT TARGET "${target}")
+        message(FATAL_ERROR "target_enable_project_warnings called for unknown target: ${target}")
+    endif()
+
+    target_compile_options("${target}" PRIVATE
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wall>"
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wextra>"
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wpedantic>"
+    )
+endfunction()
+
 set(CMAKE_CXX_STANDARD 23)
 set(CMaKE_CXX_STANDARD_REQUIRED YES)
 set(CMAKE_CXX_EXTENSIONS NO)
 
-add_compile_options(-Wall -Wextra -Wpedantic)
-
 add_executable(simple.exe
     simple.cpp)
+target_enable_project_warnings(simple.exe)
 add_executable(transform_accumulate.exe
     transform_accumulate.cpp)
+target_enable_project_warnings(transform_accumulate.exe)
 add_executable(classic_stl_to_ranges.exe
     classic_stl_to_ranges.cpp)
+target_enable_project_warnings(classic_stl_to_ranges.exe)
 add_executable(input_ranges.exe
     input_ranges.cpp)
+target_enable_project_warnings(input_ranges.exe)
 add_executable(enumerate.exe
     enumerate.cpp)
+target_enable_project_warnings(enumerate.exe)
 add_executable(projection.exe
     projection.cpp)
+target_enable_project_warnings(projection.exe)
 add_executable(particle_sort.exe
     particle_sort.cpp)
+target_enable_project_warnings(particle_sort.exe)

--- a/source-code/Regexes/CMakeLists.txt
+++ b/source-code/Regexes/CMakeLists.txt
@@ -1,6 +1,18 @@
 cmake_minimum_required(VERSION 3.20)
 project(regex_examples LANGUAGES CXX)
 
+function(target_enable_project_warnings target)
+    if(NOT TARGET "${target}")
+        message(FATAL_ERROR "target_enable_project_warnings called for unknown target: ${target}")
+    endif()
+
+    target_compile_options("${target}" PRIVATE
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wall>"
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wextra>"
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wpedantic>"
+    )
+endfunction()
+
 set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
@@ -9,5 +21,5 @@ set(APPL strings processes reformat_events simple_re_replace case word_counter)
 
 foreach(app ${APPL})
     add_executable(${app}.exe ${app}.cpp)
-    target_compile_options(${app}.exe PRIVATE -Wall)
+target_enable_project_warnings(${app}.exe)
 endforeach()

--- a/source-code/STL/CMakeLists.txt
+++ b/source-code/STL/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.16)
+cmake_minimum_required(VERSION 3.20)
 
 project(STLExamples LANGUAGES CXX)
 

--- a/source-code/STL/CMakeLists.txt
+++ b/source-code/STL/CMakeLists.txt
@@ -2,6 +2,18 @@ cmake_minimum_required(VERSION 3.16)
 
 project(STLExamples LANGUAGES CXX)
 
+function(target_enable_project_warnings target)
+    if(NOT TARGET "${target}")
+        message(FATAL_ERROR "target_enable_project_warnings called for unknown target: ${target}")
+    endif()
+
+    target_compile_options("${target}" PRIVATE
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wall>"
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wextra>"
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wpedantic>"
+    )
+endfunction()
+
 set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
@@ -28,6 +40,6 @@ endforeach()
 if(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
     foreach(source_file IN LISTS SOURCES)
         get_filename_component(target_name "${source_file}" NAME_WE)
-        target_compile_options("${target_name}" PRIVATE -Wall -Wextra -Wpedantic)
+target_enable_project_warnings(${target_name})
     endforeach()
 endif()

--- a/source-code/TOML++/RandomNumbers/CMakeLists.txt
+++ b/source-code/TOML++/RandomNumbers/CMakeLists.txt
@@ -2,6 +2,19 @@ cmake_minimum_required(VERSION 3.20)
 
 project(tomlpp_random_numbers LANGUAGES CXX)
 
+
+function(target_enable_project_warnings target)
+    if(NOT TARGET "${target}")
+        message(FATAL_ERROR "target_enable_project_warnings called for unknown target: ${target}")
+    endif()
+
+    target_compile_options("${target}" PRIVATE
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wall>"
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wextra>"
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wpedantic>"
+    )
+endfunction()
+
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
@@ -19,6 +32,7 @@ FetchContent_MakeAvailable(tomlplusplus)
 add_executable(random_from_config.exe
     main.cpp
 )
+target_enable_project_warnings(random_from_config.exe)
 
 target_link_libraries(random_from_config.exe
     PRIVATE

--- a/source-code/TOML++/Simple/CMakeLists.txt
+++ b/source-code/TOML++/Simple/CMakeLists.txt
@@ -2,6 +2,19 @@ cmake_minimum_required(VERSION 3.20)
 
 project(tomlpp_example LANGUAGES CXX)
 
+
+function(target_enable_project_warnings target)
+    if(NOT TARGET "${target}")
+        message(FATAL_ERROR "target_enable_project_warnings called for unknown target: ${target}")
+    endif()
+
+    target_compile_options("${target}" PRIVATE
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wall>"
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wextra>"
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wpedantic>"
+    )
+endfunction()
+
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
@@ -19,6 +32,7 @@ FetchContent_MakeAvailable(tomlplusplus)
 add_executable(config_demo.exe
     main.cpp
 )
+target_enable_project_warnings(config_demo.exe)
 
 target_link_libraries(config_demo.exe
     PRIVATE

--- a/source-code/Tbb/BackSubstitution/CMakeLists.txt
+++ b/source-code/Tbb/BackSubstitution/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.20)
 
 project(back_substitution LANGUAGES CXX)
 

--- a/source-code/Tbb/BackSubstitution/CMakeLists.txt
+++ b/source-code/Tbb/BackSubstitution/CMakeLists.txt
@@ -1,11 +1,9 @@
 cmake_minimum_required(VERSION 3.0)
 project(back_substitution LANGUAGES CXX)
-
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_STANDARD_REQUIRED YES)
 set(CMAKE_CXX_EXTENSIONS NO)
 
-add_compile_options(-Wall -Wextra -Wpedantic)
 
 find_package(Boost COMPONENTS program_options)
 if (NOT Boost_FOUND)

--- a/source-code/Tbb/BackSubstitution/CMakeLists.txt
+++ b/source-code/Tbb/BackSubstitution/CMakeLists.txt
@@ -1,7 +1,9 @@
 cmake_minimum_required(VERSION 3.0)
+
 project(back_substitution LANGUAGES CXX)
+
 set(CMAKE_CXX_STANDARD 17)
-set(CMAKE_STANDARD_REQUIRED YES)
+set(CMAKE_CXX_STANDARD_REQUIRED YES)
 set(CMAKE_CXX_EXTENSIONS NO)
 
 

--- a/source-code/Tbb/BackSubstitution/src/CMakeLists.txt
+++ b/source-code/Tbb/BackSubstitution/src/CMakeLists.txt
@@ -1,1 +1,14 @@
+function(target_enable_project_warnings target)
+    if(NOT TARGET "${target}")
+        message(FATAL_ERROR "target_enable_project_warnings called for unknown target: ${target}")
+    endif()
+
+    target_compile_options("${target}" PRIVATE
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wall>"
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wextra>"
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wpedantic>"
+    )
+endfunction()
+
 add_executable(back_subst_serial.exe back_substitution_serial.cpp equations.cpp solver.cpp)
+target_enable_project_warnings(back_subst_serial.exe)

--- a/source-code/Tbb/CMakeLists.txt
+++ b/source-code/Tbb/CMakeLists.txt
@@ -1,6 +1,18 @@
 cmake_minimum_required(VERSION 3.20)
 project(tbb_examples LANGUAGES CXX)
 
+function(target_enable_project_warnings target)
+    if(NOT TARGET "${target}")
+        message(FATAL_ERROR "target_enable_project_warnings called for unknown target: ${target}")
+    endif()
+
+    target_compile_options("${target}" PRIVATE
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wall>"
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wextra>"
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wpedantic>"
+    )
+endfunction()
+
 set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
@@ -23,6 +35,6 @@ set(
 
 foreach(app ${APPL})
     add_executable(${app}.exe ${app}.cpp)
-    target_compile_options(${app}.exe PRIVATE -Wall -Wextra)
+target_enable_project_warnings(${app}.exe)
     target_link_libraries(${app}.exe PRIVATE TBB::tbb m)
 endforeach()

--- a/source-code/Tbb/JuliaSet/CMakeLists.txt
+++ b/source-code/Tbb/JuliaSet/CMakeLists.txt
@@ -1,6 +1,18 @@
 cmake_minimum_required(VERSION 3.20)
 project(tbb_julia_examples LANGUAGES CXX)
 
+function(target_enable_project_warnings target)
+    if(NOT TARGET "${target}")
+        message(FATAL_ERROR "target_enable_project_warnings called for unknown target: ${target}")
+    endif()
+
+    target_compile_options("${target}" PRIVATE
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wall>"
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wextra>"
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wpedantic>"
+    )
+endfunction()
+
 set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
@@ -15,7 +27,7 @@ add_executable(julia_omp.exe julia_omp.cpp)
 add_executable(julia_tasks_omp.exe julia_tasks_omp.cpp)
 
 foreach(app julia_abs.exe julia.exe julia_tbb.exe julia_omp.exe julia_tasks_omp.exe)
-    target_compile_options(${app} PRIVATE -Wall -Wextra -Wpedantic)
+target_enable_project_warnings(${app})
     target_link_libraries(${app} PRIVATE m)
 endforeach()
 

--- a/source-code/Tbb/LineOfSight/CMakeLists.txt
+++ b/source-code/Tbb/LineOfSight/CMakeLists.txt
@@ -5,12 +5,10 @@ if(POLICY CMP0167)
 endif()
 
 project(line_of_sight LANGUAGES CXX)
-
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED YES)
 set(CMAKE_CXX_EXTENSIONS NO)
 
-add_compile_options(-Wall -Wextra -Wpedantic)
 
 find_package(Boost CONFIG REQUIRED COMPONENTS program_options)
 include(${CMAKE_CURRENT_SOURCE_DIR}/../cmake/FetchTBB.cmake)

--- a/source-code/Tbb/LineOfSight/src/CMakeLists.txt
+++ b/source-code/Tbb/LineOfSight/src/CMakeLists.txt
@@ -1,9 +1,25 @@
+function(target_enable_project_warnings target)
+    if(NOT TARGET "${target}")
+        message(FATAL_ERROR "target_enable_project_warnings called for unknown target: ${target}")
+    endif()
+
+    target_compile_options("${target}" PRIVATE
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wall>"
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wextra>"
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wpedantic>"
+    )
+endfunction()
+
 add_executable(terrain.exe terrain.cpp terrain_main.cpp)
+target_enable_project_warnings(terrain.exe)
 target_link_libraries(terrain.exe PRIVATE Boost::program_options)
 
 add_executable(los_serial.exe terrain.cpp line_of_sight_serial.cpp)
+target_enable_project_warnings(los_serial.exe)
 
 add_executable(visibility_serial.exe terrain.cpp visibility_serial.cpp)
+target_enable_project_warnings(visibility_serial.exe)
 
 add_executable(visibility_par.exe terrain.cpp visibility_par.cpp)
+target_enable_project_warnings(visibility_par.exe)
 target_link_libraries(visibility_par.exe PRIVATE TBB::tbb)

--- a/source-code/Tbb/Tree/CMakeLists.txt
+++ b/source-code/Tbb/Tree/CMakeLists.txt
@@ -1,11 +1,9 @@
 cmake_minimum_required(VERSION 3.20)
 project(tbb_tree LANGUAGES CXX)
-
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED YES)
 set(CMAKE_CXX_EXTENSIONS NO)
 
-add_compile_options(-Wall -Wextra -Wpedantic)
 
 include(${CMAKE_CURRENT_SOURCE_DIR}/../cmake/FetchTBB.cmake)
 

--- a/source-code/Tbb/Tree/src/CMakeLists.txt
+++ b/source-code/Tbb/Tree/src/CMakeLists.txt
@@ -1,2 +1,15 @@
+function(target_enable_project_warnings target)
+    if(NOT TARGET "${target}")
+        message(FATAL_ERROR "target_enable_project_warnings called for unknown target: ${target}")
+    endif()
+
+    target_compile_options("${target}" PRIVATE
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wall>"
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wextra>"
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wpedantic>"
+    )
+endfunction()
+
 add_executable(tree_test.exe main_tree_test.cpp tree_init.cpp)
+target_enable_project_warnings(tree_test.exe)
 target_link_libraries(tree_test.exe PRIVATE TBB::tbb)

--- a/source-code/Templates/ArrayView/CMakeLists.txt
+++ b/source-code/Templates/ArrayView/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.18)
+cmake_minimum_required(VERSION 3.20)
 project(array_view LANGUAGES CXX)
 
 

--- a/source-code/Templates/ArrayView/CMakeLists.txt
+++ b/source-code/Templates/ArrayView/CMakeLists.txt
@@ -1,8 +1,22 @@
 cmake_minimum_required(VERSION 3.18)
 project(array_view LANGUAGES CXX)
 
+
+function(target_enable_project_warnings target)
+    if(NOT TARGET "${target}")
+        message(FATAL_ERROR "target_enable_project_warnings called for unknown target: ${target}")
+    endif()
+
+    target_compile_options("${target}" PRIVATE
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wall>"
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wextra>"
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wpedantic>"
+    )
+endfunction()
+
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
 add_executable(test_array_views.exe test_array_views.cpp)
+target_enable_project_warnings(test_array_views.exe)

--- a/source-code/Templates/CMakeLists.txt
+++ b/source-code/Templates/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.16)
+cmake_minimum_required(VERSION 3.20)
 
 project(Templates LANGUAGES CXX)
 

--- a/source-code/Templates/CMakeLists.txt
+++ b/source-code/Templates/CMakeLists.txt
@@ -2,6 +2,18 @@ cmake_minimum_required(VERSION 3.16)
 
 project(Templates LANGUAGES CXX)
 
+function(target_enable_project_warnings target)
+    if(NOT TARGET "${target}")
+        message(FATAL_ERROR "target_enable_project_warnings called for unknown target: ${target}")
+    endif()
+
+    target_compile_options("${target}" PRIVATE
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wall>"
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wextra>"
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wpedantic>"
+    )
+endfunction()
+
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
@@ -9,7 +21,7 @@ set(CMAKE_CXX_EXTENSIONS OFF)
 # Match Makefile output naming convention.
 set(CMAKE_EXECUTABLE_SUFFIX .exe)
 
-add_compile_options(-O2 -g -Wall -Wextra)
+add_compile_options(-O2 -g)
 
 set(APPLICATIONS
     swap
@@ -21,5 +33,6 @@ set(APPLICATIONS
 
 foreach(app IN LISTS APPLICATIONS)
     add_executable(${app} ${app}.cpp)
+    target_enable_project_warnings(${app})
     target_link_libraries(${app} PRIVATE m)
 endforeach()

--- a/source-code/Templates/Concepts/DeduceThis/CMakeLists.txt
+++ b/source-code/Templates/Concepts/DeduceThis/CMakeLists.txt
@@ -2,6 +2,18 @@ cmake_minimum_required(VERSION 3.20)
 
 project(simulations LANGUAGES CXX)
 
+function(target_enable_project_warnings target)
+    if(NOT TARGET "${target}")
+        message(FATAL_ERROR "target_enable_project_warnings called for unknown target: ${target}")
+    endif()
+
+    target_compile_options("${target}" PRIVATE
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wall>"
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wextra>"
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wpedantic>"
+    )
+endfunction()
+
 set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
@@ -13,6 +25,5 @@ set(SIMULATIONS
 foreach(SIMULATION ${SIMULATIONS})
     add_executable(${SIMULATION}.exe
         main_${SIMULATION}.cpp)
-    target_compile_options(${SIMULATION}.exe
-        PRIVATE -Wall -Wextra -Wpedantic)
+target_enable_project_warnings(${SIMULATION}.exe)
 endforeach()

--- a/source-code/Templates/Concepts/Simple/CMakeLists.txt
+++ b/source-code/Templates/Concepts/Simple/CMakeLists.txt
@@ -1,10 +1,21 @@
 cmake_minimum_required(VERSION 3.20)
 project(grids LANGUAGES CXX)
 
+function(target_enable_project_warnings target)
+    if(NOT TARGET "${target}")
+        message(FATAL_ERROR "target_enable_project_warnings called for unknown target: ${target}")
+    endif()
+
+    target_compile_options("${target}" PRIVATE
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wall>"
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wextra>"
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wpedantic>"
+    )
+endfunction()
+
 set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_STANDARD_REQUIRED YES)
 set(CMAKE_CXX_EXTENSIONS NO)
 
-add_compile_options(-Wall -Wextra -Wpedantic)
-
 add_executable(iterable.exe main.cpp)
+target_enable_project_warnings(iterable.exe)

--- a/source-code/Templates/Counter/CMakeLists.txt
+++ b/source-code/Templates/Counter/CMakeLists.txt
@@ -1,8 +1,22 @@
 cmake_minimum_required(VERSION 3.20)
 project(counter LANGUAGES CXX)
 
+
+function(target_enable_project_warnings target)
+    if(NOT TARGET "${target}")
+        message(FATAL_ERROR "target_enable_project_warnings called for unknown target: ${target}")
+    endif()
+
+    target_compile_options("${target}" PRIVATE
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wall>"
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wextra>"
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wpedantic>"
+    )
+endfunction()
+
 set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
 add_executable(test_counter.exe main_counter.cpp)
+target_enable_project_warnings(test_counter.exe)

--- a/source-code/Templates/Grid/CMakeLists.txt
+++ b/source-code/Templates/Grid/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.20)
 project(grids LANGUAGES CXX)
 
 function(target_enable_project_warnings target)

--- a/source-code/Templates/Grid/CMakeLists.txt
+++ b/source-code/Templates/Grid/CMakeLists.txt
@@ -1,11 +1,23 @@
 cmake_minimum_required(VERSION 3.0)
 project(grids LANGUAGES CXX)
 
+function(target_enable_project_warnings target)
+    if(NOT TARGET "${target}")
+        message(FATAL_ERROR "target_enable_project_warnings called for unknown target: ${target}")
+    endif()
+
+    target_compile_options("${target}" PRIVATE
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wall>"
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wextra>"
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wpedantic>"
+    )
+endfunction()
+
 set(CMAKE_CXX_STANDARD 17)
 set(CMaKE_CXX_STANDARD_REQUIRED YES)
 set(CMAKE_CXX_EXTENSIONS NO)
 
-add_compile_options(-Wall -Wextra -Wpedantic)
-
 add_executable(grid.exe main.cpp)
+target_enable_project_warnings(grid.exe)
 add_executable(grid2.exe main2.cpp)
+target_enable_project_warnings(grid2.exe)

--- a/source-code/Templates/Shapes/Subclasses/CMakeLists.txt
+++ b/source-code/Templates/Shapes/Subclasses/CMakeLists.txt
@@ -2,8 +2,22 @@ cmake_minimum_required(VERSION 3.20)
 
 project(subclasses_shapes LANGUAGES CXX)
 
+
+function(target_enable_project_warnings target)
+    if(NOT TARGET "${target}")
+        message(FATAL_ERROR "target_enable_project_warnings called for unknown target: ${target}")
+    endif()
+
+    target_compile_options("${target}" PRIVATE
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wall>"
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wextra>"
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wpedantic>"
+    )
+endfunction()
+
 set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
 add_executable(subclasses_shapes.exe main.cpp)
+target_enable_project_warnings(subclasses_shapes.exe)

--- a/source-code/Templates/Shapes/Subclasses/main.cpp
+++ b/source-code/Templates/Shapes/Subclasses/main.cpp
@@ -1,6 +1,7 @@
 #include <algorithm>
 #include <chrono>
 #include <iostream>
+#include <memory>
 #include <random>
 #include <vector>
 #include "circle.h"
@@ -8,7 +9,7 @@
 #include "square.h"
 #include "triangle.h"
 
-using Data = std::vector<Shape*>;
+using Data = std::vector<std::unique_ptr<Shape>>;
 
 double total_area(const Data& data) {
     double total = 0;
@@ -26,13 +27,13 @@ Data create_shapes(std::size_t nr_shapes) {
     for (std::size_t i = 0; i < nr_shapes; ++i) {
         switch (shape_dist(gen)) {
             case 0:
-                data.push_back(new Circle(size_dist(gen)));
+                data.push_back(std::make_unique<Circle>(size_dist(gen)));
                 break;
             case 1:
-                data.push_back(new Square(size_dist(gen)));
+                data.push_back(std::make_unique<Square>(size_dist(gen)));
                 break;
             case 2:
-                data.push_back(new Triangle(size_dist(gen), size_dist(gen)));
+                data.push_back(std::make_unique<Triangle>(size_dist(gen), size_dist(gen)));
                 break;
         }
     }
@@ -45,9 +46,6 @@ int main(int argc, char* argv[]) {
         nr_shapes = std::stoul(argv[1]);
     }
     auto start = std::chrono::high_resolution_clock::now();
-    /*
-    Data data = create_shapes(nr_shapes);
-    */
     Data data {create_shapes(nr_shapes)};   
     auto end = std::chrono::high_resolution_clock::now();
     std::cout << "Time to create: "

--- a/source-code/Templates/Shapes/TypeErasure/CMakeLists.txt
+++ b/source-code/Templates/Shapes/TypeErasure/CMakeLists.txt
@@ -2,8 +2,22 @@ cmake_minimum_required(VERSION 3.20)
 
 project(type_erasure_shapes LANGUAGES CXX)
 
+
+function(target_enable_project_warnings target)
+    if(NOT TARGET "${target}")
+        message(FATAL_ERROR "target_enable_project_warnings called for unknown target: ${target}")
+    endif()
+
+    target_compile_options("${target}" PRIVATE
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wall>"
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wextra>"
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wpedantic>"
+    )
+endfunction()
+
 set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
 add_executable(type_erasure_shapes.exe main.cpp)
+target_enable_project_warnings(type_erasure_shapes.exe)

--- a/source-code/Templates/Shapes/TypeErasure/main.cpp
+++ b/source-code/Templates/Shapes/TypeErasure/main.cpp
@@ -13,15 +13,21 @@ void create_shapes(AreaAggregator& aggr, std::size_t nr_shapes) {
     std::uniform_int_distribution<int> shape_dist(0, 2);
     for (std::size_t i = 0; i < nr_shapes; ++i) {
         switch (shape_dist(gen)) {
-            case 0:
-                aggr.add(new Circle(size_dist(gen)));
+            case 0: {
+                Circle c(size_dist(gen));
+                aggr.add(c);
                 break;
-            case 1:
-                aggr.add(new Square(size_dist(gen)));
+            }
+            case 1: {
+                Square s(size_dist(gen));
+                aggr.add(s);
                 break;
-            case 2:
-                aggr.add(new Triangle(size_dist(gen), size_dist(gen)));
+            }
+            case 2: {
+                Triangle t(size_dist(gen), size_dist(gen));
+                aggr.add(t);
                 break;
+            }
         }
     }
 }

--- a/source-code/Templates/Shapes/TypeErasure/shape.h
+++ b/source-code/Templates/Shapes/TypeErasure/shape.h
@@ -3,6 +3,7 @@
 
 #include <memory>
 #include <vector>
+#include <utility>
 
 struct AreaAggregator {
     private:

--- a/source-code/Templates/Shapes/TypeErasure/shape.h
+++ b/source-code/Templates/Shapes/TypeErasure/shape.h
@@ -1,6 +1,7 @@
 #ifndef SHAPE_HDR
 #define SHAPE_HDR
 
+#include <memory>
 #include <vector>
 
 struct AreaAggregator {
@@ -15,20 +16,19 @@ struct AreaAggregator {
         template<typename T>
         struct ShapeModel: public ShapeConcept {
             private:
-                const T* shape_;
+                T shape_;
             public:
-                explicit ShapeModel(const T* shape) : shape_(shape) {}
-                double area() const override { return shape_->area(); }
-                double perimeter() const override { return shape_->perimeter(); }
-                T* get() const { return shape_; }
+                explicit ShapeModel(T shape) : shape_{std::move(shape)} {}
+                double area() const override { return shape_.area(); }
+                double perimeter() const override { return shape_.perimeter(); }
         };
         
-        std::vector<ShapeConcept*> shapes_;
+        std::vector<std::unique_ptr<ShapeConcept>> shapes_;
         
     public:
         template<typename T>
-        void add(const T* shape) {
-            shapes_.push_back(new ShapeModel<T>(shape));
+        void add(T shape) {
+            shapes_.push_back(std::make_unique<ShapeModel<T>>(std::move(shape)));
         }
         double total_area() const {
             double total = 0;

--- a/source-code/Templates/Shapes/Variant/CMakeLists.txt
+++ b/source-code/Templates/Shapes/Variant/CMakeLists.txt
@@ -2,8 +2,22 @@ cmake_minimum_required(VERSION 3.20)
 
 project(variant_shapes LANGUAGES CXX)
 
+
+function(target_enable_project_warnings target)
+    if(NOT TARGET "${target}")
+        message(FATAL_ERROR "target_enable_project_warnings called for unknown target: ${target}")
+    endif()
+
+    target_compile_options("${target}" PRIVATE
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wall>"
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wextra>"
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wpedantic>"
+    )
+endfunction()
+
 set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
 add_executable(variant_shapes.exe main.cpp)
+target_enable_project_warnings(variant_shapes.exe)

--- a/source-code/UserDefinedTypes/CMakeLists.txt
+++ b/source-code/UserDefinedTypes/CMakeLists.txt
@@ -2,13 +2,21 @@ cmake_minimum_required(VERSION 3.16)
 
 project(UserDefinedTypes LANGUAGES CXX)
 
+function(target_enable_project_warnings target)
+    if(NOT TARGET "${target}")
+        message(FATAL_ERROR "target_enable_project_warnings called for unknown target: ${target}")
+    endif()
+
+    target_compile_options("${target}" PRIVATE
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wall>"
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wextra>"
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wpedantic>"
+    )
+endfunction()
+
 set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
-
-if(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
-  add_compile_options(-Wall -Wextra -Wpedantic)
-endif()
 
 set(EXECUTABLE_SOURCES
   struct_particles.cpp
@@ -22,6 +30,7 @@ set(EXECUTABLE_SOURCES
 foreach(source_file IN LISTS EXECUTABLE_SOURCES)
   get_filename_component(target_name "${source_file}" NAME_WE)
   add_executable("${target_name}" "${source_file}")
+  target_enable_project_warnings("${target_name}")
   set_target_properties("${target_name}" PROPERTIES
     OUTPUT_NAME "${target_name}.exe"
   )

--- a/source-code/UserDefinedTypes/CMakeLists.txt
+++ b/source-code/UserDefinedTypes/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.16)
+cmake_minimum_required(VERSION 3.20)
 
 project(UserDefinedTypes LANGUAGES CXX)
 

--- a/source-code/UserDefinedTypes/Explicit/CMakeLists.txt
+++ b/source-code/UserDefinedTypes/Explicit/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.20)
 
 project(explicit_or_not LANGUAGES CXX)
 

--- a/source-code/UserDefinedTypes/Explicit/CMakeLists.txt
+++ b/source-code/UserDefinedTypes/Explicit/CMakeLists.txt
@@ -2,8 +2,22 @@ cmake_minimum_required(VERSION 3.10)
 
 project(explicit_or_not LANGUAGES CXX)
 
+
+function(target_enable_project_warnings target)
+    if(NOT TARGET "${target}")
+        message(FATAL_ERROR "target_enable_project_warnings called for unknown target: ${target}")
+    endif()
+
+    target_compile_options("${target}" PRIVATE
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wall>"
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wextra>"
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wpedantic>"
+    )
+endfunction()
+
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
 add_executable(explicit_or_not.exe explicit_or_not.cpp)
+target_enable_project_warnings(explicit_or_not.exe)

--- a/source-code/UserDefinedTypes/Matrices/CMakeLists.txt
+++ b/source-code/UserDefinedTypes/Matrices/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.18)
+cmake_minimum_required(VERSION 3.20)
 project(algorithms LANGUAGES CXX)
 
 function(target_enable_project_warnings target)

--- a/source-code/UserDefinedTypes/Matrices/CMakeLists.txt
+++ b/source-code/UserDefinedTypes/Matrices/CMakeLists.txt
@@ -1,11 +1,22 @@
 cmake_minimum_required(VERSION 3.18)
 project(algorithms LANGUAGES CXX)
 
+function(target_enable_project_warnings target)
+    if(NOT TARGET "${target}")
+        message(FATAL_ERROR "target_enable_project_warnings called for unknown target: ${target}")
+    endif()
+
+    target_compile_options("${target}" PRIVATE
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wall>"
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wextra>"
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wpedantic>"
+    )
+endfunction()
+
 set(CMAKE_CXX_STANDARD 23)
 set(CMaKE_CXX_STANDARD_REQUIRED YES)
 set(CMAKE_CXX_EXTENSIONS NO)
 
-add_compile_options(-Wall -Wextra -Wpedantic)
-
 add_executable(matrix_test.exe
     matrix_test.cpp)
+target_enable_project_warnings(matrix_test.exe)

--- a/source-code/UserDefinedTypes/ObjectLifeCycle/CMakeLists.txt
+++ b/source-code/UserDefinedTypes/ObjectLifeCycle/CMakeLists.txt
@@ -2,10 +2,25 @@ cmake_minimum_required(VERSION 3.20)
 
 project(object_life_cycle LANGUAGES CXX)
 
+
+function(target_enable_project_warnings target)
+    if(NOT TARGET "${target}")
+        message(FATAL_ERROR "target_enable_project_warnings called for unknown target: ${target}")
+    endif()
+
+    target_compile_options("${target}" PRIVATE
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wall>"
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wextra>"
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wpedantic>"
+    )
+endfunction()
+
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
 add_executable(gadget.exe gadget.cpp)
+target_enable_project_warnings(gadget.exe)
 
 add_executable(emplace.exe emplace.cpp)
+target_enable_project_warnings(emplace.exe)

--- a/source-code/UserDefinedTypes/RuleOfFive/CMakeLists.txt
+++ b/source-code/UserDefinedTypes/RuleOfFive/CMakeLists.txt
@@ -1,11 +1,22 @@
 cmake_minimum_required(VERSION 3.20)
 project(rule_of_five LANGUAGES CXX)
 
+function(target_enable_project_warnings target)
+    if(NOT TARGET "${target}")
+        message(FATAL_ERROR "target_enable_project_warnings called for unknown target: ${target}")
+    endif()
+
+    target_compile_options("${target}" PRIVATE
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wall>"
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wextra>"
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wpedantic>"
+    )
+endfunction()
+
 set(CMAKE_CXX_STANDARD 20)
 set(CMaKE_CXX_STANDARD_REQUIRED YES)
 set(CMAKE_CXX_EXTENSIONS NO)
 
-add_compile_options(-Wall -Wextra -Wpedantic)
-
 add_executable(buffer.exe
     main.cpp)
+target_enable_project_warnings(buffer.exe)

--- a/source-code/UserDefinedTypes/TableStats/CMakeLists.txt
+++ b/source-code/UserDefinedTypes/TableStats/CMakeLists.txt
@@ -2,13 +2,24 @@ cmake_minimum_required(VERSION 3.20)
 
 project(table_stats CXX)
 
+function(target_enable_project_warnings target)
+    if(NOT TARGET "${target}")
+        message(FATAL_ERROR "target_enable_project_warnings called for unknown target: ${target}")
+    endif()
+
+    target_compile_options("${target}" PRIVATE
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wall>"
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wextra>"
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wpedantic>"
+    )
+endfunction()
+
 # C++ standard settings
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
 # Common compiler flags
-set(COMMON_FLAGS -Wall -Wextra -Wpedantic)
 
 # Link libraries (e.g., -lm for math)
 set(COMMON_LIBS m)
@@ -17,7 +28,7 @@ set(COMMON_LIBS m)
 add_executable(stats.exe
     stats.cpp
     stats_main.cpp)
-target_compile_options(stats.exe PRIVATE ${COMMON_FLAGS})
+target_enable_project_warnings(stats.exe)
 target_link_libraries(stats.exe PRIVATE ${COMMON_LIBS})
 
 # table_stats executable
@@ -25,5 +36,5 @@ add_executable(table_stats.exe
     stats.cpp
     table_stats.cpp
     table_stats_main.cpp)
-target_compile_options(table_stats.exe PRIVATE ${COMMON_FLAGS})
+target_enable_project_warnings(table_stats.exe)
 target_link_libraries(table_stats.exe PRIVATE ${COMMON_LIBS})

--- a/source-code/UsingCLibraries/CMakeLists.txt
+++ b/source-code/UsingCLibraries/CMakeLists.txt
@@ -1,6 +1,18 @@
 cmake_minimum_required(VERSION 3.20)
 project(using_c_libraries_examples LANGUAGES CXX)
 
+function(target_enable_project_warnings target)
+    if(NOT TARGET "${target}")
+        message(FATAL_ERROR "target_enable_project_warnings called for unknown target: ${target}")
+    endif()
+
+    target_compile_options("${target}" PRIVATE
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wall>"
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wextra>"
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wpedantic>"
+    )
+endfunction()
+
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
@@ -12,7 +24,7 @@ set(APPL cannon_max_range minimum)
 
 foreach(app ${APPL})
     add_executable(${app}.exe ${app}.cpp)
-    target_compile_options(${app}.exe PRIVATE -Wall -Wextra)
+target_enable_project_warnings(${app}.exe)
     target_include_directories(${app}.exe PRIVATE ${GSL_INCLUDE_DIRS})
     target_link_directories(${app}.exe PRIVATE ${GSL_LIBRARY_DIRS})
     target_link_libraries(${app}.exe PRIVATE ${GSL_LIBRARIES})

--- a/source-code/Vcpkg/CMakeLists.txt
+++ b/source-code/Vcpkg/CMakeLists.txt
@@ -1,14 +1,24 @@
 cmake_minimum_required(VERSION 3.0)
 project(eigen LANGUAGES CXX)
 
+function(target_enable_project_warnings target)
+    if(NOT TARGET "${target}")
+        message(FATAL_ERROR "target_enable_project_warnings called for unknown target: ${target}")
+    endif()
+
+    target_compile_options("${target}" PRIVATE
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wall>"
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wextra>"
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wpedantic>"
+    )
+endfunction()
+
 set(CMAKE_CXX_STANDARD 20)
 set(CMaKE_CXX_STANDARD_REQUIRED YES)
 set(CMAKE_CXX_EXTENSIONS NO)
 
-add_compile_options(-Wall -Wextra -Wpedantic)
-
 find_package(Eigen3 CONFIG REQUIRED)
 
 add_executable(read_matrix.exe read_matrix.cpp)
+target_enable_project_warnings(read_matrix.exe)
 target_link_libraries(read_matrix.exe PRIVATE Eigen3::Eigen)
-

--- a/source-code/Vcpkg/CMakeLists.txt
+++ b/source-code/Vcpkg/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.20)
 project(eigen LANGUAGES CXX)
 
 function(target_enable_project_warnings target)

--- a/source-code/Xtensor/CMakeLists.txt
+++ b/source-code/Xtensor/CMakeLists.txt
@@ -1,6 +1,18 @@
 cmake_minimum_required(VERSION 3.20)
 project(xtensor_examples LANGUAGES CXX)
 
+function(target_enable_project_warnings target)
+    if(NOT TARGET "${target}")
+        message(FATAL_ERROR "target_enable_project_warnings called for unknown target: ${target}")
+    endif()
+
+    target_compile_options("${target}" PRIVATE
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wall>"
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wextra>"
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,IntelLLVM>:-Wpedantic>"
+    )
+endfunction()
+
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
@@ -45,7 +57,7 @@ add_executable(elementwise.exe elementwise.cpp)
 add_executable(svd.exe svd.cpp)
 
 foreach(app elementwise.exe svd.exe)
-    target_compile_options(${app} PRIVATE -Wall -Wextra)
+target_enable_project_warnings(${app})
     target_link_libraries(${app} PRIVATE m xtensor xtensor-blas)
 endforeach()
 


### PR DESCRIPTION
## Summary by Sourcery

Introduce shared CMake helper functions to consistently enable compiler warnings across targets and modernize various example projects’ CMake configurations.

Enhancements:
- Add reusable CMake functions to enable consistent warning flags per target and per language, and apply them across numerous example executables and libraries.
- Modernize CMake usage by preferring target-specific compile options, updating minimum required CMake versions, and using Boost/Eigen CONFIG targets where available.
- Refactor several example applications to eliminate manual memory management in shape type-erasure and subclass examples by adopting value semantics and smart pointers for shape storage.

Build:
- Align warning, optimization, and debug flag handling with target-based CMake patterns, reducing reliance on global add_compile_options and CMAKE_CXX_FLAGS.